### PR TITLE
[Do not merge] Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: 3.6
 install:
   - pip install --upgrade pip
-  - pip install flake8 pytest
+  - pip install flake8 pytest psycopg2
   - pip install -r requirements.txt
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ install:
   - pip install --upgrade pip
   - pip install flake8 pytest
   - pip install -r requirements.txt
+services:
+  - postgresql
 before_script:
+  - psql -c 'create database infobase_test;' -U postgres
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,F822,F823 --show-source --statistics
   # TODO: add this E999,F821 test to the line above once they have been fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ matrix:
   allow_failures:
     - python: 3.6
 install:
+  - pip install --upgrade pip
   - pip install flake8 pytest
+  - pip install -r requirements.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E901,F822,F823 --show-source --statistics
+  # TODO: add this E999,F821 test to the line above once they have been fixed
+  - flake8 . --count --exit-zero --select=E999,F821 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: pytest

--- a/infogami/__init__.py
+++ b/infogami/__init__.py
@@ -1,10 +1,13 @@
 """Infogami: Structured Wiki (http://infogami.org)"""
+from __future__ import print_function
 
 __version__ = "0.5dev"
 
-import web
-import config
 import sys
+
+import web
+
+from infogami import config
 
 usage = """
 Infogami
@@ -69,15 +72,15 @@ def help(name=None):
     
     a = name and find_action(name)
 
-    print "Infogami Help"
-    print ""
+    print("Infogami Help")
+    print("")
 
     if a:
-        print "    %s\t%s" %  (a.__name__, a.__doc__)
+        print("    %s\t%s" %  (a.__name__, a.__doc__))
     else:
-        print "Available actions"
+        print("Available actions")
         for a in _actions:
-            print "    %s\t%s" %  (a.__name__, a.__doc__)
+            print("    %s\t%s" %  (a.__name__, a.__doc__))
 
 @action
 def install():
@@ -93,7 +96,7 @@ def install():
 
     delegate.admin_login()
     for a in _install_hooks:
-        print >> web.debug, a.__name__
+        print(a.__name__, file=web.debug)
         a()
 
 @action
@@ -127,14 +130,15 @@ def runscript(filename, *args):
     """
     sys.argv = [filename] + list(args)
     g = {"__name__": "__main__"}
-    execfile(filename, g, g)
+    with open(filename) as in_file:
+        exec(in_file, g, g)
 
 def run_action(name, args=[]):
     a = find_action(name)
     if a:
         a(*args)
     else:
-        print >> sys.stderr, 'unknown command', name
+        print('unknown command', name, file=sys.stderr)
         help()
 
 def run(args=None):

--- a/infogami/conftest.py
+++ b/infogami/conftest.py
@@ -1,6 +1,3 @@
-
-# pytest_plugins = ["pytest_unittest"]
-
 collect_ignore = ['failing']
 
 def pytest_addoption(parser):
@@ -9,4 +6,3 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     if config.getvalue("runall"):
         collect_ignore[:] = []
-

--- a/infogami/conftest.py
+++ b/infogami/conftest.py
@@ -1,5 +1,5 @@
 
-pytest_plugins = ["pytest_unittest"]
+# pytest_plugins = ["pytest_unittest"]
 
 collect_ignore = ['failing']
 

--- a/infogami/core/code.py
+++ b/infogami/core/code.py
@@ -118,7 +118,7 @@ class edit (delegate.mode):
                 p._save(comment)
                 path = web.input(_method='GET', redirect=None).redirect or web.changequery(query={})
                 raise web.seeother(path)
-            except (ClientException, db.ValidationException), e:            
+            except (ClientException, db.ValidationException) as e:            
                 add_flash_message('error', str(e))
                 p['comment_'] = comment                
                 return render.editpage(p)
@@ -127,7 +127,7 @@ class edit (delegate.mode):
             
             try:
                 web.ctx.site.save(q, comment)
-            except (ClientException, db.ValidationException), e:            
+            except (ClientException, db.ValidationException) as e:            
                 add_flash_message('error', str(e))
                 p['comment_'] = comment                
                 return render.editpage(p)
@@ -168,7 +168,7 @@ class permission(delegate.mode):
         
         try:
             web.ctx.site.write(q)
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc(e)
             add_flash_message('error', str(e))
@@ -233,7 +233,7 @@ class login(delegate.page):
         i = web.input(remember=False, redirect='/')
         try:
             web.ctx.site.login(i.username, i.password, i.remember)
-        except Exception, e:
+        except Exception as e:
             f = forms.login()
             f.fill(i)
             f.note = str(e)
@@ -261,7 +261,7 @@ class register(delegate.page):
             from infogami.infobase.client import ClientException
             try:
                 web.ctx.site.register(i.username, i.displayname, i.email, i.password)
-            except ClientException, e:
+            except ClientException as e:
                 f.note = str(e)
                 return render.register(f)
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
@@ -292,7 +292,7 @@ class forgot_password(delegate.page):
             try:
                 delegate.admin_login()
                 d = web.ctx.site.get_reset_code(i.email)
-            except ClientException, e:
+            except ClientException as e:
                 f.note = str(e)
                 web.ctx.headers = []
                 return render.forgot_password(f)
@@ -321,7 +321,7 @@ class reset_password(delegate.page):
                 web.ctx.site.reset_password(i.username, i.code, i.password)
                 web.ctx.site.login(i.username, i.password, False)
                 raise web.seeother('/')
-            except Exception, e:
+            except Exception as e:
                 return "Failed to reset password.<br/><br/> Reason: "  + str(e)
         
 _preferences = []
@@ -353,7 +353,7 @@ class change_password(delegate.page):
         else:
             try:
                 user = web.ctx.site.update_user(i.oldpassword, i.password, None)
-            except ClientException, e:
+            except ClientException as e:
                 f.note = str(e)
                 return render.login_preferences(f)
             add_flash_message('info', 'Password updated successfully.')

--- a/infogami/core/db.py
+++ b/infogami/core/db.py
@@ -4,13 +4,18 @@ import pickle
 import infogami
 from infogami.utils.view import public
 
+try:
+    basestring
+except NameError:
+    basestring = (str, )
+
 def get_version(path, revision=None):
     return web.ctx.site.get(path, revision)
 
 @public
 def get_type(path):
     return get_version(path)
-    
+
 @public
 def get_expected_type(page, property_name):
     """Returns the expected type of a property."""
@@ -20,37 +25,37 @@ def get_expected_type(page, property_name):
         "permission": "/type/permission",
         "child_permission": "/type/permission"
     }
-    
+
     if property_name in defaults:
         return defaults[property_name]
-    
+
     for p in page.type.properties:
         if p.name == property_name:
             return p.expected_type
 
     return "/type/string"
-    
+
 def new_version(path, type):
     if isinstance(type, basestring):
         type = get_type(type)
-    
+
     assert type is not None
     return web.ctx.site.new(path, {'key': path, 'type': type})
-    
+
 @public
 def get_i18n_page(page):
     key = page.key
     if key == '/':
-	key = '/index'
+        key = '/index'
     def get(lang):
-       return lang and get_version(key + '.' + lang)
+        return lang and get_version(key + '.' + lang)
     return get(web.ctx.lang) or get('en') or None
 
 class ValidationException(Exception): pass
-    
+
 def get_user_preferences(user):
     return get_version(user.key + '/preferences')
-    
+
 @public
 def get_recent_changes(key=None, author=None, ip=None, type=None, bot=None, limit=None, offset=None):
     q = {'sort': '-created'}
@@ -65,10 +70,10 @@ def get_recent_changes(key=None, author=None, ip=None, type=None, bot=None, limi
 
     if ip:
         q['ip'] = ip
-        
+
     if bot is not None:
         q['bot'] = bot
-    
+
     q['limit'] = limit or 100
     q['offset'] = offset or 0
     result = web.ctx.site.versions(q)
@@ -80,30 +85,29 @@ def get_recent_changes(key=None, author=None, ip=None, type=None, bot=None, limi
 def list_pages(path, limit=100, offset=0):
     """Lists all pages with name path/*"""
     return _list_pages(path, limit=limit, offset=offset)
-    
+
 def _list_pages(path, limit, offset):
     q = {}
     if path != '/':
         q['key~'] = path + '/*'
-    
+
     # don't show /type/delete and /type/redirect
     q['a:type!='] = '/type/delete'
     q['b:type!='] = '/type/redirect'
-    
+
     q['sort'] = 'key'
     q['limit'] = limit
     q['offset'] = offset
     # queries are very slow with != conditions
     # q['type'] != '/type/delete'
     return [web.ctx.site.get(key, lazy=True) for key in web.ctx.site.things(q)]
-                   
+
 def get_things(typename, prefix, limit):
-    """Lists all things whose names start with typename"""	
+    """Lists all things whose names start with typename"""
     q = {
         'key~': prefix + '*',
         'type': typename,
         'sort': 'key',
         'limit': limit
     }
-    return [web.ctx.site.get(key, lazy=True) for key in web.ctx.site.things(q)]    
-    
+    return [web.ctx.site.get(key, lazy=True) for key in web.ctx.site.things(q)]

--- a/infogami/core/dbupgrade.py
+++ b/infogami/core/dbupgrade.py
@@ -1,6 +1,7 @@
 """
 module for doing database upgrades when code changes. 
 """
+from __future__ import print_function
 import infogami
 from infogami import tdb
 
@@ -24,14 +25,14 @@ def apply_upgrades():
     try:
         v = get_db_version()
         for u in upgrades[v:]:
-            print >> web.debug, 'applying upgrade:', u.__name__
+            print('applying upgrade:', u.__name__, file=web.debug)
             u()
         
         mark_upgrades()
         tdb.commit()
-        print >> web.debug, 'upgrade successful.'
+        print('upgrade successful.', file=web.debug)
     except:
-        print >> web.debug, 'upgrade failed'
+        print('upgrade failed', file=web.debug)
         import traceback
         traceback.print_exc()
         tdb.rollback()
@@ -76,7 +77,7 @@ def upgrade_types():
     for t in types:
         properties = []
         backreferences = []
-        print >> web.debug, t, t.d
+        print(t, t.d, file=web.debug)
         if t.name == 'type/site':
             continue
         for name, value in t.d.items():

--- a/infogami/infobase/__init__.py
+++ b/infogami/infobase/__init__.py
@@ -1,10 +1,14 @@
 """
 Infobase.
 """
+from __future__ import print_function
+
+import logging
 import sys
+
 import web
 
-import config, infobase, logger, logreader
+from infogami.infobase import config, infobase, logreader
 
 commands = {}
 def command(f):
@@ -14,9 +18,9 @@ def command(f):
 @command
 def help():
     """Prints this help."""
-    print "Infobase help\n\nCommands:\n"
+    print("Infobase help\n\nCommands:\n")
     for name, c in commands.items():
-        print "%-20s %s" % (name, c.__doc__)
+        print("%-20s %s" % (name, c.__doc__))
 
 @command
 def createsite(sitename, admin_password):

--- a/infogami/infobase/_dbstore/indexer.py
+++ b/infogami/infobase/_dbstore/indexer.py
@@ -1,6 +1,12 @@
 from infogami.infobase import common
 import web
 
+try:
+    basestring
+except NameError:
+    basestring = (str, )
+
+
 class Indexer:
     """Indexer computes the values to be indexed.
     

--- a/infogami/infobase/_dbstore/read.py
+++ b/infogami/infobase/_dbstore/read.py
@@ -5,6 +5,12 @@ import simplejson
 import web
 from infogami.infobase import config
 
+try:
+    basestring
+except NameError:
+    basestring = (str, )
+
+
 def get_user_root():
     user_root = config.get("user_root", "/user")
     return user_root.rstrip("/") + "/"

--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -4,10 +4,14 @@ import web
 import simplejson
 from collections import defaultdict
 
-from indexer import Indexer
-from schema import INDEXED_DATATYPES, Schema
-
 from infogami.infobase import config, common
+from infogami.infobase._dbstore.indexer import Indexer
+from infogami.infobase._dbstore.schema import INDEXED_DATATYPES, Schema
+
+try:
+    basestring
+except NameError:
+    basestring = (str, )
 
 __all__ = ["SaveImpl"]
 

--- a/infogami/infobase/_dbstore/store.py
+++ b/infogami/infobase/_dbstore/store.py
@@ -30,8 +30,6 @@ The following indexer allows querying for books using lowercase titles and books
             
 """
 
-from __future__ import with_statement
-
 import simplejson
 import web
 

--- a/infogami/infobase/account.py
+++ b/infogami/infobase/account.py
@@ -6,8 +6,7 @@ import web
 import logging
 import simplejson
 
-import common
-import config
+from infogami.infobase import common, config
 
 logger = logging.getLogger("infobase.account")
 

--- a/infogami/infobase/bulkupload.py
+++ b/infogami/infobase/bulkupload.py
@@ -3,10 +3,11 @@ bulkupload script to upload multiple objects at once.
 All the inserts are merged to give better performance.
 """
 import web
-from infobase import TYPES, DATATYPE_REFERENCE
 import datetime
 import re
 import tempfile
+
+from infogami.infobase import TYPES, DATATYPE_REFERENCE
 
 def sqlin(name, values):
     """
@@ -254,7 +255,7 @@ class BulkUpload:
         elif isinstance(query, bool):
             return (int(query), TYPES['/type/boolean'])
         else:
-            raise Exception, '%s: invalid value: %s' (path, repr(query))
+            raise Exception('%s: invalid value: %s' (path, repr(query)))
 
 if __name__ == "__main__":
     import sys

--- a/infogami/infobase/cache.py
+++ b/infogami/infobase/cache.py
@@ -28,15 +28,17 @@ Any elements added to the infobase cache during a request are cached locally unt
 of that request and then they are added to the global cache.
 """
 
-import web
-import lru
 import logging
+
+import web
+
+from infogami.infobase import lru
 
 logger = logging.getLogger("infobase.cache")
 
 class NoneDict:
     def __getitem__(self, key):
-        raise KeyError, key
+        raise KeyError(key)
         
     def __setitem__(self, key, value):
         pass
@@ -55,7 +57,7 @@ class MemcachedDict:
         key = web.safestr(key)
         value = self.memcache_client.get(key)
         if value is None:
-            raise KeyError, key
+            raise KeyError(key)
         return value
         
     def __setitem__(self, key, value):

--- a/infogami/infobase/common.py
+++ b/infogami/infobase/common.py
@@ -1,8 +1,8 @@
-import config
 import web
 
-from core import *
-from utils import *
+from infogami.infobase import config
+from infogami.infobase.core import *
+from infogami.infobase.utils import *
 
 # Primitive types and corresponding python types
 primitive_types = {

--- a/infogami/infobase/core.py
+++ b/infogami/infobase/core.py
@@ -1,8 +1,14 @@
 """Core datastructures for Infogami.
 """
 import web
-import _json as simplejson
+from infogami.infobase import _json as simplejson
 import copy
+
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class InfobaseException(Exception):
     status = "500 Internal Server Error"
@@ -90,7 +96,7 @@ class Thing:
         try:
             return self[key]
         except KeyError:
-            raise AttributeError, key
+            raise AttributeError(key)
             
     def __eq__(self, other):
         return getattr(other, 'key', None) == self.key and getattr(other, '_data', None) == self._data

--- a/infogami/infobase/dbstore.py
+++ b/infogami/infobase/dbstore.py
@@ -1,18 +1,23 @@
 """Infobase Implementation based on database.
 """
-import common
-import config
-import web
-import _json as simplejson
-import datetime, time
-from collections import defaultdict
+import datetime
 import logging
+import time
+from collections import defaultdict
 
-from _dbstore import store, sequence
-from _dbstore.schema import Schema, INDEXED_DATATYPES
-from _dbstore.indexer import Indexer
-from _dbstore.save import SaveImpl, PropertyManager
-from _dbstore.read import RecentChanges, get_bot_users
+import web
+
+from infogami.infobase import config, common, _json as simplejson
+from infogami.infobase._dbstore import store, sequence
+from infogami.infobase._dbstore.schema import Schema, INDEXED_DATATYPES
+from infogami.infobase._dbstore.indexer import Indexer
+from infogami.infobase._dbstore.save import SaveImpl, PropertyManager
+from infogami.infobase._dbstore.read import RecentChanges, get_bot_users
+
+try:
+    unicode
+except NameError:
+    unicode = str
 
 default_schema = None
 

--- a/infogami/infobase/infobase.py
+++ b/infogami/infobase/infobase.py
@@ -4,17 +4,17 @@ Infobase: structured database.
 Infobase is a structured database which contains multiple sites.
 Each site is an independent collection of objects. 
 """
-import web
-import datetime
-import simplejson
+from __future__ import print_function
 
-import common
-import config
-import readquery
-import writequery
+import datetime
+
+import simplejson
+import web
+
+from infogami.infobase import common, config, readquery, writequery
 
 # important: this is required here to setup _loadhooks and unloadhooks
-import cache
+from infogami.infobase import cache
 
 class Infobase:
     """Infobase contains multiple sites."""
@@ -242,7 +242,7 @@ class Site:
                 try:
                     t(self, old, new)
                 except:
-                    print >> web.debug, 'Failed to execute trigger', t
+                    print('Failed to execute trigger', t, file=web.debug)
                     import traceback
                     traceback.print_exc()
         

--- a/infogami/infobase/logger.py
+++ b/infogami/infobase/logger.py
@@ -10,10 +10,12 @@ Infogami log file is a stream of events where each event is a dictionary represe
 Log files are circulated on daily basis. Default log file format is $logroot/yyyy/mm/dd.log.
 """
 
-import datetime, time
-import _json as simplejson
+import datetime
 import os
 import threading
+import time
+
+from infogami.infobase import _json as simplejson
 
 def synchronize(f):
     """decorator to synchronize a method."""

--- a/infogami/infobase/logreader.py
+++ b/infogami/infobase/logreader.py
@@ -1,6 +1,7 @@
 """
 Log file reader.
 """
+from __future__ import print_function
 import os
 import itertools
 import datetime
@@ -9,7 +10,7 @@ import web
 import glob
 
 try:
-    import _json as simplejson
+    from infogami.infobase import _json as simplejson
 except ImportError:
     # make sure this module can be used indepent of infobase.
     import simplejson
@@ -187,8 +188,7 @@ class LogFile:
         
     def find_filelist(self, from_date=None):
         if from_date is None:
-            filelist = glob.glob('%s/[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9].log' % self.root)
-            filelist.sort()
+            filelist = sorted(glob.glob('%s/[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9].log' % self.root))
         else:
             filelist = [self.date2file(date) for date in daterange(from_date)]
             filelist = [f for f in filelist if os.path.exists(f)]
@@ -282,7 +282,7 @@ class RsyncLogFile(LogFile):
         
     def rsync(self):
         cmd = "rsync -r %s %s" % (self.rsync_root, self.root)
-        print cmd
+        print(cmd)
         os.system(cmd)
 
 class LogPlayback:

--- a/infogami/infobase/lru.py
+++ b/infogami/infobase/lru.py
@@ -61,7 +61,7 @@ class Queue:
     def peek(self):
         """Returns the element at the begining of the queue."""
         if self.head.next is self.head:
-            raise Exception, "Queue is empty"
+            raise Exception("Queue is empty")
         return self.head.next
         
     def remove(self, node=None):
@@ -176,7 +176,7 @@ class LRU:
     @synchronized
     def __delitem__(self, key):
         if key not in self.d:
-            raise KeyError, key
+            raise KeyError(key)
         node = self.getnode(key, touch=False)
         self.remove_node(node)
         

--- a/infogami/infobase/multiple_insert.py
+++ b/infogami/infobase/multiple_insert.py
@@ -39,7 +39,7 @@ def multiple_insert(tablename, values, seqname=None, _test=False):
     # make sure all rows have same keys.
     for v in values:
         if v.keys() != keys:
-            raise Exception, 'Bad data'
+            raise Exception('Bad data')
 
     q = web.SQLQuery('INSERT INTO %s (%s) VALUES ' % (tablename, ', '.join(keys))) 
 

--- a/infogami/infobase/readquery.py
+++ b/infogami/infobase/readquery.py
@@ -1,8 +1,11 @@
-import common
-from common import all, any
-import web
+
 import re
-import _json as simplejson
+
+import web
+
+from infogami.infobase import common, _json as simplejson
+from infogami.infobase.common import all, any
+
 
 def get_thing(store, key, revision=None):
     json = key and store.get(key, revision)
@@ -250,7 +253,7 @@ def make_versions_query(store, query):
     
     for k, v in query.items():
         if k not in columns:
-            raise ValueError, k
+            raise ValueError(k)
         q.add_condition(k, '=', None, v)
         
     return q

--- a/infogami/infobase/server.py
+++ b/infogami/infobase/server.py
@@ -9,7 +9,7 @@ import time
 
 import web
 
-from infogami.infobase import cache, common, logreader, _json as simplejson
+from infogami.infobase import cache, common, infobase, logreader, _json as simplejson
 from infogami.infobase.account import get_user_root
 
 __version__ = "0.5dev"

--- a/infogami/infobase/server.py
+++ b/infogami/infobase/server.py
@@ -9,6 +9,7 @@ import time
 
 import web
 
+from infogami import config
 from infogami.infobase import cache, common, infobase, logreader, _json as simplejson
 from infogami.infobase.account import get_user_root
 

--- a/infogami/infobase/tests/conftest.py
+++ b/infogami/infobase/tests/conftest.py
@@ -1,2 +1,2 @@
 
-from pytest_wildcard import *
+from infogami.infobase.tests.pytest_wildcard import *

--- a/infogami/infobase/tests/pytest_wildcard.py
+++ b/infogami/infobase/tests/pytest_wildcard.py
@@ -1,6 +1,8 @@
 """py.test wildcard plugin.
 """
 
+import pytest
+
 class Wildcard:
     """Wildcard object is equal to anything.
     
@@ -26,7 +28,8 @@ def test_wildcard():
     assert 1 == wildcard
     assert ["foo", 1, 2] == [wildcard, 1, 2]
 
-def pytest_funcarg__wildcard(request):
+@pytest.fixture
+def wildcard(request):
     """Returns the wildcard object.
     
     Wildcard object is equal to anything. It is useful in testing datastuctures with some random parts. 

--- a/infogami/infobase/tests/test_account.py
+++ b/infogami/infobase/tests/test_account.py
@@ -1,9 +1,10 @@
-import utils
+import pytest
+
 import web
 
 from infogami.infobase import server, account, bootstrap, common
+from infogami.infobase.tests import utils
 
-import pytest
 
 def setup_module(mod):
     utils.setup_site(mod)
@@ -15,7 +16,7 @@ def teardown_module(mod):
 class TestAccount:
     def setup_method(self, method):
         self.tx = db.transaction()
-    
+
     def teardown_method(self, method):
         self.tx.rollback()
         site.cache.clear()
@@ -23,7 +24,7 @@ class TestAccount:
     def test_register(self):
         a = site.account_manager
         a.register(username="joe", email="joe@example.com", password="secret", data={})
-        
+
         # login should fail before activation 
         assert a.login('joe', 'secret') == "account_not_verified"
         assert a.login('joe', 'wrong-password') == "account_bad_password"
@@ -32,23 +33,23 @@ class TestAccount:
 
         assert a.login('joe', 'secret') == "ok"
         assert a.login('joe', 'wrong-password') == "account_bad_password"
-        
+
     def test_register_failures(self, _activate=True):
         a = site.account_manager
         a.register(username="joe", email="joe@example.com", password="secret", data={}, _activate=_activate)
-        
+
         try:
             a.register(username="joe", email="joe2@example.com", password="secret", data={})
             assert False
-        except common.BadData, e:
+        except common.BadData as e:
             assert e.d['message'] == "User already exists: joe"
-            
+
         try:
             a.register(username="joe2", email="joe@example.com", password="secret", data={})
             assert False
-        except common.BadData, e:
+        except common.BadData as e:
             assert e.d['message'] == "Email is already used: joe@example.com"
-            
+
     def test_register_failures2(self):
         # test registeration without activation + registration with same username/email
         self.test_register_failures(_activate=False)
@@ -57,11 +58,11 @@ class TestAccount:
         """Generates encrypted password from raw password."""
         a = site.account_manager
         return a._generate_salted_hash(a.secret_key, password)
-        
+
     def test_login_account(self):
         f = site.account_manager._verify_login
         enc_password = self.encrypt("secret")
-        
+
         assert f(dict(enc_password=enc_password, status="active"), "secret") == "ok"
         assert f(dict(enc_password=enc_password, status="active"), "bad-password") == "account_bad_password"
 
@@ -81,16 +82,14 @@ class TestAccount:
         assert a.login("foo", "more-secret") == "ok"
 
         ## test update email
-        
+
         # registering with the same email should fail.
         assert pytest.raises(common.BadData, a.register, username="bar", email="foo@example.com", password="secret", data={})
-        
+
         assert a.update("foo", email="foo2@example.com") == "ok"
-        
+
         # someone else should be able to register with the old email
         a.register(username="bar", email="foo@example.com", password="secret", data={})
-        
+
         # and no one should be allowed to register with new email
         assert pytest.raises(common.BadData, a.register, username="bar", email="foo2@example.com", password="secret", data={})
-        
-        

--- a/infogami/infobase/tests/test_infobase.py
+++ b/infogami/infobase/tests/test_infobase.py
@@ -1,13 +1,14 @@
+from __future__ import print_function
+
 import os
+
 import simplejson
-import urllib
-
 import py.test
-
 import web
-from infogami.infobase import config, dbstore, infobase, server
 
-import utils
+from infogami.infobase import config, dbstore, infobase, server
+from infogami.infobase.tests import utils
+
 
 def setup_module(mod):
     utils.setup_site(mod)
@@ -85,8 +86,8 @@ class TestInfobase(DBTest):
             {'key': '/foo', 'revision': 1, 'comment': 'test 1'},
         ]
         
-        print self.create_user('test', 'testt@example.com', 'test123', data={'displayname': 'Test'})
-        print site._get_thing('/user/test')
+        print(self.create_user('test', 'testt@example.com', 'test123', data={'displayname': 'Test'}))
+        print(site._get_thing('/user/test'))
         site.save('/foo', {'key': '/foo', 'type': '/type/object', 'x': 2}, comment='test 4', ip='1.2.3.4', author=site._get_thing('/user/test'))
         
         assert versions({'author': '/user/test'})[:-3] == [
@@ -133,10 +134,10 @@ class TestInfobase(DBTest):
         site.save_many(q)
         
     def test_things(self):
-        print >> web.debug, "save /a"
+        print("save /a", file=web.debug)
         site.save('/a', {'key': '/a', 'type': '/type/object', 'x': 1, 'name': 'a'})
 
-        print >> web.debug, "save /b"
+        print("save /b", file=web.debug)
         site.save('/b', {'key': '/b', 'type': '/type/object', 'x': 2, 'name': 'b'})
         
         assert site.things({'type': '/type/object'}) == [{'key': '/a'}, {'key': '/b'}]

--- a/infogami/infobase/tests/test_read.py
+++ b/infogami/infobase/tests/test_read.py
@@ -1,11 +1,11 @@
+import datetime
+
 from infogami.infobase import dbstore
 from infogami.infobase._dbstore.save import SaveImpl
 from infogami.infobase._dbstore.store import Store
 from infogami.infobase._dbstore.read import RecentChanges
+from infogami.infobase.tests import utils
 
-import utils
-
-import datetime
 
 def setup_module(mod):
     utils.setup_db(mod)
@@ -23,7 +23,7 @@ class DBTest:
 
 class TestRecentChanges(DBTest):
     def _save(self, docs, author=None, ip="1.2.3.4", comment="testing", kind="test_save", timestamp=None, data=None):
-        timestamp = timestamp=timestamp or datetime.datetime(2010, 01, 02, 03, 04, 05)
+        timestamp = timestamp=timestamp or datetime.datetime(2010, 1, 2, 3, 4, 5)
         s = SaveImpl(db)
         s.save(docs, 
             timestamp=timestamp,
@@ -54,7 +54,7 @@ class TestRecentChanges(DBTest):
             {"key": "/foo", "type": {"key": "/type/object"}, "title": "foo"},
             {"key": "/bar", "type": {"key": "/type/object"}, "title": "bar"}
         ]
-        timestamp = datetime.datetime(2010, 01, 02, 03, 04, 05)
+        timestamp = datetime.datetime(2010, 1, 2, 3, 4, 5)
         self._save(docs, comment="testing recentchanges", timestamp=timestamp)
 
         engine = RecentChanges(db)

--- a/infogami/infobase/tests/test_save.py
+++ b/infogami/infobase/tests/test_save.py
@@ -1,13 +1,14 @@
+import datetime
+import os
+import unittest
+
+import pytest
+import simplejson
+import web
+
 from infogami.infobase import dbstore
 from infogami.infobase._dbstore.save import SaveImpl, IndexUtil, PropertyManager
-
-import utils
-
-import web
-import simplejson
-import os
-import datetime
-import unittest
+from infogami.infobase.tests import utils
 
 def setup_module(mod):
     utils.setup_db(mod)
@@ -57,7 +58,7 @@ class Test_get_records_for_save(DBTest):
     """
     def test_new(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
 
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         b = {"key": "/b", "type": {"key": "/type/object"}, "title": "b"}
@@ -74,12 +75,12 @@ class Test_get_records_for_save(DBTest):
             id =  db.insert('thing', key=doc['key'], latest_revision=revision, created=created, last_modified=last_modified)
             db.insert('data', seqname=False, thing_id=id, revision=revision, data=simplejson.dumps(doc))
         
-        created = datetime.datetime(2010, 01, 01, 01, 01, 01)            
+        created = datetime.datetime(2010, 1, 1, 1, 1, 1)            
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         insert(a, 1, created, created)
 
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 02, 02, 02, 02, 02)            
+        timestamp = datetime.datetime(2010, 2, 2, 2, 2, 2)            
         records = s._get_records_for_save([a], timestamp)
         
         assert_record(records[0], a, 2, created, timestamp)
@@ -91,7 +92,7 @@ class Test_save(DBTest):
         
     def test_save(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         
         status = s.save([a], 
@@ -105,7 +106,7 @@ class Test_save(DBTest):
         assert self.get_json('/a') == update_doc(a, 1, timestamp, timestamp) 
         
         a['title'] = 'b'
-        timestamp2 = datetime.datetime(2010, 02, 02, 02, 02, 02) 
+        timestamp2 = datetime.datetime(2010, 2, 2, 2, 2, 2) 
         status = s.save([a], 
                     timestamp=timestamp2, 
                     ip="1.2.3.4", 
@@ -117,7 +118,7 @@ class Test_save(DBTest):
         
     def test_type_change(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         status = s.save([a], 
                     timestamp=timestamp, 
@@ -130,7 +131,7 @@ class Test_save(DBTest):
         type_delete_id = db.insert("thing", key='/type/delete')
         a['type']['key'] = '/type/delete'
 
-        timestamp2 = datetime.datetime(2010, 02, 02, 02, 02, 02) 
+        timestamp2 = datetime.datetime(2010, 2, 2, 2, 2, 2) 
         status = s.save([a], 
                     timestamp=timestamp2, 
                     ip="1.2.3.4", 
@@ -172,7 +173,7 @@ class Test_save(DBTest):
         
     def _save(self, docs):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         return s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
     
     def test_save_with_new_type(self):
@@ -184,7 +185,7 @@ class Test_save(DBTest):
             "type": {"key": "/type/foo"}
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         
         s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
         
@@ -211,7 +212,7 @@ class Test_save(DBTest):
             "title": "a" * 4000
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
         
     def test_transaction(self, wildcard):
@@ -220,7 +221,7 @@ class Test_save(DBTest):
             "type": {"key": "/type/object"},
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         changeset = s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
         changeset.pop("docs")
         changeset.pop("old_docs")
@@ -255,7 +256,8 @@ class MockSchema:
     def find_table(self, type, datatype, name):
         return "datum_" + datatype
         
-def pytest_funcarg__testdata(request):        
+@pytest.fixture
+def testdata(request):        
     return {
         "doc1": {
             "key": "/doc1",
@@ -391,7 +393,7 @@ class TestIndex:
 class TestIndexWithDB(DBTest):
     def _save(self, docs):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         return s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
     
     def test_reindex(self):

--- a/infogami/infobase/tests/test_seq.py
+++ b/infogami/infobase/tests/test_seq.py
@@ -1,5 +1,5 @@
 from infogami.infobase._dbstore.sequence import SequenceImpl
-import utils
+from infogami.infobase.tests import utils
 
 import unittest
 import simplejson

--- a/infogami/infobase/tests/test_store.py
+++ b/infogami/infobase/tests/test_store.py
@@ -1,7 +1,6 @@
-from infogami.infobase._dbstore.store import Store, TypewiseIndexer
 from infogami.infobase import common
-
-import utils
+from infogami.infobase._dbstore.store import Store, TypewiseIndexer
+from infogami.infobase.tests import utils
 
 import simplejson
 import py.test

--- a/infogami/infobase/tests/test_writequery.py
+++ b/infogami/infobase/tests/test_writequery.py
@@ -1,7 +1,7 @@
 import web
 
-import utils
-from .. import common, writequery
+from infogami.infobase import common, writequery
+from infogami.infobase.tests import utils
 
 def setup_module(mod):
     utils.setup_site(mod)
@@ -69,7 +69,7 @@ class TestSaveProcessor(DBTest):
         def save_many(query):
             try:
                 site.save_many(query)
-            except common.InfobaseException, e:
+            except common.InfobaseException as e:
                 return e.dict()
 
         q = {

--- a/infogami/infobase/utils.py
+++ b/infogami/infobase/utils.py
@@ -1,5 +1,6 @@
 """Generic utilities.
 """
+from __future__ import print_function
 import datetime
 import re
 import web
@@ -84,7 +85,7 @@ def pprint(obj):
     {
     }
     """
-    print prepr(obj)
+    print(prepr(obj))
     
 def prepr(obj, indent=""):
     """Pretty representaion."""

--- a/infogami/infobase/writequery.py
+++ b/infogami/infobase/writequery.py
@@ -1,10 +1,17 @@
 """
 """
-import common
-from common import pprint, any, all
-import web
 import simplejson
-import account
+import web
+
+from infogami.infobase import account, common
+from infogami.infobase.common import all, any, pprint
+
+try:
+    basestring
+    unicode
+except NameError:
+    basestring = (str, )
+    unicode = str
 
 def get_thing(store, key, revision=None):
     if isinstance(key, common.Reference):
@@ -258,7 +265,7 @@ class SaveProcessor:
                     value = common.primitive_types[expected_type](value)
                 elif type_found == '/type/int' and expected_type == '/type/float':
                     value = float(value)
-            except ValueError, e:
+            except ValueError as e:
                 raise common.BadData(message=str(e), at=at, value=value)
         elif property.expected_type.kind == 'embeddable':
             if isinstance(value, dict):

--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -66,7 +66,7 @@ class infobase_request:
         try:
             out = conn.request(sitename, path, method, data)
             return '{"status": "ok", "result": %s}' % out
-        except client.ClientException, e:
+        except client.ClientException as e:
             return '{"status": "fail", "message": "%s"}' % str(e)
     
     GET = delegate
@@ -96,7 +96,7 @@ class infobase_request:
         
         try:
             out = conn.request(sitename, path, method, data)
-        except client.ClientException, e:
+        except client.ClientException as e:
             raise BadRequest(e.json or str(e))
             
         #@@ this should be done in the connection.
@@ -108,7 +108,7 @@ class infobase_request:
                 result = simplejson.loads(out)
                 for k in result.get('created', []) + result.get('updated', []):
                     web.ctx.site._run_hooks("on_new_version", request("/get", data=dict(key=k)))
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc()
         return out
@@ -127,7 +127,7 @@ def jsonapi(f):
     def g(*a, **kw):
         try:
             out = f(*a, **kw)
-        except client.ClientException, e:
+        except client.ClientException as e:
             raise web.HTTPError(e.status, {}, e.json or str(e))
         
         i = web.input(_method='GET', callback=None)
@@ -255,5 +255,5 @@ class login(delegate.page):
             d = simplejson.loads(web.data())
             web.ctx.site.login(d['username'], d['password'])
             web.setcookie(infogami.config.login_cookie_name, web.ctx.conn.get_auth_token())
-        except Exception, e:
+        except Exception as e:
             raise BadRequest(str(e))

--- a/infogami/plugins/pages/code.py
+++ b/infogami/plugins/pages/code.py
@@ -7,6 +7,7 @@ push moves pages from disk to wiki and pull moves pages from wiki to disk.
 TODOs:
 * As of now pages are stored as python dict. Replace it with a human-readable format.
 """
+from __future__ import print_function
 
 import web
 import os
@@ -157,7 +158,7 @@ def pull(root, paths_files):
             paths2.append(path)
 
     for path in paths2:
-        print >> web.debug, "pulling page", path
+        print("pulling page", path, file=web.debug)
         page = db.get_version(context.site, path)
         name = page.name or '__root__'
         data = thing2dict(page)
@@ -174,7 +175,7 @@ def _pushpages(pages):
     tdb.transact()
     try:
         for p in pages.values(): 
-            print 'saving', p.name
+            print('saving', p.name)
             _savepage(p)    
     except:
         tdb.rollback()
@@ -255,7 +256,7 @@ def datadump(filename):
 @infogami.action
 def dataload(filename):
     """"Loads data dumped using datadump action into the database."""
-    lines = open(filename).xreadlines()
+    lines = open(filename)
     tdb.transact()
     try:
         for line in lines:

--- a/infogami/plugins/wikitemplates/code.py
+++ b/infogami/plugins/wikitemplates/code.py
@@ -1,6 +1,7 @@
 """
 wikitemplates: allow keeping templates and macros in wiki
 """
+from __future__ import print_function
 
 import web
 import os
@@ -32,7 +33,7 @@ class WikiSource(DictMixin):
         key = self.process_key(key)
         root = self.getroot()
         if root is None or context.get('rescue_mode'):
-            raise KeyError, key
+            raise KeyError(key)
         
         root = web.rstrips(root or "", "/")
         value = self.templates[root + key]    
@@ -123,8 +124,8 @@ def _compile_template(name, text):
             
     try:
         return web.template.Template(text, filter=web.websafe, filename=name)
-    except (web.template.ParseError, SyntaxError), e:
-        print >> web.debug, 'Template parsing failed for ', name
+    except (web.template.ParseError, SyntaxError) as e:
+        print('Template parsing failed for ', name, file=web.debug)
         import traceback
         traceback.print_exc()
         raise ValidationException("Template parsing failed: " + str(e))
@@ -193,7 +194,7 @@ def movetemplates(prefix_pattern=None):
             try:
                 t.func()
             except:
-                print >> web.debug, 'unable to load template', t.name
+                print('unable to load template', t.name, file=web.debug)
                 raise
     
     for name, t in template.disktemplates.items():
@@ -208,9 +209,9 @@ def movetemplates(prefix_pattern=None):
     delegate.admin_login()
     result = web.ctx.site.write(templates)
     for p in result.created:
-        print "created", p
+        print("created", p)
     for p in result.updated:
-        print "updated", p
+        print("updated", p)
         
 @infogami.install_hook
 @infogami.action
@@ -230,9 +231,9 @@ def movemacros():
     delegate.admin_login()
     result = web.ctx.site.write(macros)
     for p in result.created:
-        print "created", p
+        print("created", p)
     for p in result.updated:
-        print "updated", p
+        print("updated", p)
 
 def _wikiname(name, prefix, suffix):
     base, extn = os.path.splitext(name)
@@ -284,7 +285,7 @@ def monkey_patch_debugerror():
         else:
             return open(filename)
             
-    web.debugerror.func_globals['open'] = xopen
+    web.debugerror.__globals__['open'] = xopen
 
 from infogami.core.code import register_preferences
 register_preferences(template_preferences)

--- a/infogami/plugins/wikitemplates/forms.py
+++ b/infogami/plugins/wikitemplates/forms.py
@@ -1,5 +1,6 @@
+from __future__ import print_function
 import web
-from web.form import *
+from web.form import Button, Form, Textbox
 from infogami.utils import i18n
 
 class BetterButton(Button):
@@ -17,4 +18,4 @@ template_preferences = Form(
 )
 
 if __name__ == "__main__":
-    print template_preferences().render()
+    print(template_preferences().render())

--- a/infogami/utils/app.py
+++ b/infogami/utils/app.py
@@ -7,7 +7,7 @@ import simplejson
 
 import web
 
-from infogami.utils import flash, delegate as infogami_delegate
+from infogami.utils import flash
 
 urls = ("/.*", "item")
 app = web.application(urls, globals(), autoreload=False)

--- a/infogami/utils/app.py
+++ b/infogami/utils/app.py
@@ -7,8 +7,7 @@ import simplejson
 
 import web
 
-import flash
-import delegate as infogami_delegate
+from infogami.utils import flash, delegate as infogami_delegate
 
 urls = ("/.*", "item")
 app = web.application(urls, globals(), autoreload=False)

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -1,17 +1,13 @@
-import os.path
-import re
+import os
+
 import web
+
 from infogami import config
+from infogami.utils import features, i18n, macro, template
+from infogami.utils.app import *
+from infogami.utils.context import context
+from infogami.utils.view import render_site, public
 
-import template
-import macro
-from context import context
-import features
-
-from app import *
-
-from view import render_site, public
-import i18n
 
 def create_site():
     from infogami.infobase import client
@@ -131,7 +127,7 @@ def _make_plugin(name):
             if os.path.isdir(path):
                 break
         else:
-            raise Exception, 'Plugin not found: ' + name
+            raise Exception('Plugin not found: ' + name)
             
     return web.storage(name=name, path=path, module=module)
 

--- a/infogami/utils/features.py
+++ b/infogami/utils/features.py
@@ -2,7 +2,7 @@
 """
 import web
 
-from context import context
+from infogami.utils.context import context
 
 feature_flags = {}
 

--- a/infogami/utils/i18n.py
+++ b/infogami/utils/i18n.py
@@ -1,6 +1,7 @@
 """
 Support for Internationalization.
 """
+from __future__ import print_function
 
 import web
 
@@ -67,7 +68,7 @@ class i18n:
         if not key.startswith('__'):
             return self[key]
         else:
-            raise AttributeError, key
+            raise AttributeError(key)
             
     def __getitem__(self, key):
         namespace = web.ctx.get('i18n_namespace', '/')
@@ -83,7 +84,7 @@ class i18n_namespace:
         if not key.startswith('__'):
             return self[key]
         else:
-            raise AttributeError, key
+            raise AttributeError(key)
             
     def __getitem__(self, key):
         return self._i18n.get(self._namespace, key)
@@ -107,7 +108,7 @@ class i18n_string:
             a = [x or "" for x in a]
             return str(self) % tuple(web.utf8(x) for x in a)
         except:
-            print >> web.debug, 'failed to substitute (%s/%s) in language %s' % (self._namespace, self._key, web.ctx.lang)
+            print('failed to substitute (%s/%s) in language %s' % (self._namespace, self._key, web.ctx.lang), file=web.debug)
         return str(self)
 
 def i18n_loadhook():
@@ -171,11 +172,12 @@ def load_strings(plugin_path):
         """Find namespace and lang from path."""
         namespace = os.path.dirname(path)
         _, extn = os.path.splitext(p)
-        return '/' + namespace, extn[1:] # strip dot
+        return '/' + namespace, extn[1:]  # strip dot
         
     def read_strings(path):
         env = {}
-        execfile(path, env)
+        with open(path) as in_file:
+            exec(in_file, env)
         # __builtins__ gets added by execfile
         del env['__builtins__']
         return env
@@ -189,7 +191,7 @@ def load_strings(plugin_path):
         except:
             import traceback
             traceback.print_exc()
-            print >> web.debug, "failed to load strings from", p
+            print("failed to load strings from", p, file=web.debug)
 
 # global state
 strings = i18n()

--- a/infogami/utils/macro.py
+++ b/infogami/utils/macro.py
@@ -3,12 +3,15 @@ Macro extension to markdown.
 
 Macros take argument string as input and returns result as markdown text.
 """
-from markdown import markdown
-import web
+from __future__ import print_function
+
 import os
 
-import template
-import storage
+import web
+
+from infogami.utils import storage
+from infogami.utils import template
+from infogami.utils.markdown import markdown
 
 # macros loaded from disk
 diskmacros = template.DiskTemplateSource()
@@ -49,7 +52,7 @@ def call_macro(name, args):
             macro = macrostore[name]
             args, kwargs = safeeval_args(args)
             result = macro(*args, **kwargs)
-        except Exception, e:
+        except Exception as e:
             i = web.input(_method="GET", debug="false")
             if i.debug.lower() == "true":
                 raise
@@ -122,4 +125,4 @@ if __name__ == "__main__":
     md = markdown.Markdown(source=text, safe_mode=False)
     MacroExtension().extendMarkdown(md, {})
     html = md.convert()
-    print replace_macros(html, md.macros)
+    print(replace_macros(html, md.macros))

--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 version = "1.6b"
 version_info = (1,6,2,"rc-2")
 __revision__ = "$Rev$"
@@ -28,8 +29,12 @@ License: GPL 2 (http://www.gnu.org/copyleft/gpl.html) or BSD
 
 """
 
-
 import re, sys, os, random, codecs
+
+try:
+    basestring
+except NameError:
+    basestring = (str, )
 
 # Set debug level: 3 none, 2 critical, 1 informative, 0 all
 (VERBOSE, INFO, CRITICAL, NONE) = range(4)
@@ -38,7 +43,7 @@ MESSAGE_THRESHOLD = CRITICAL
 
 def message(level, text) :
     if level >= MESSAGE_THRESHOLD :
-        print text
+        print(text)
 
 
 # --------------- CONSTANTS YOU MIGHT WANT TO MODIFY -----------------
@@ -312,7 +317,7 @@ class Element :
         if self.nodeName in ['p', 'li', 'ul', 'ol',
                              'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] :
 
-            if not self.attribute_values.has_key("dir"):
+            if "dir" not in self.attribute_values:
                 if self.bidi :
                     bidi = self.bidi
                 else :
@@ -796,7 +801,7 @@ class ReferencePattern (Pattern):
             # we'll use "google" as the id
             id = m.group(2).lower()
 
-        if not self.references.has_key(id) : # ignore undefined refs
+        if id not in self.references : # ignore undefined refs
             return None
         href, title = self.references[id]
         text = m.group(2)
@@ -1135,7 +1140,7 @@ class Markdown:
                         % (ext, extension_module_name) )
             else :
 
-                if configs.has_key(ext) :
+                if ext in configs :
                     configs_for_ext = configs[ext]
                 else :
                     configs_for_ext = []
@@ -1497,7 +1502,7 @@ class Markdown:
                 
                 x = parts[i]
 
-                if isinstance(x, (str, unicode)) :
+                if isinstance(x, basestring) :
                     result = self._applyPattern(x, pattern)
 
                     if result :
@@ -1510,7 +1515,7 @@ class Markdown:
 
         for i in range(len(parts)) :
             x = parts[i]
-            if isinstance(x, (str, unicode)) :
+            if isinstance(x, basestring) :
                 parts[i] = self.doc.createTextNode(x)
 
         return parts
@@ -1585,7 +1590,7 @@ class Markdown:
 
                             for item in result:
 
-                                if isinstance(item, (str, unicode)):
+                                if isinstance(item, basestring):
                                     if len(item) > 0:
                                         node.insertChild(position,
                                              self.doc.createTextNode(item))
@@ -1731,7 +1736,7 @@ class Extension :
         self.config = configs
 
     def getConfig(self, key) :
-        if self.config.has_key(key) :
+        if key in self.config :
             return self.config[key][0]
         else :
             return ""
@@ -1765,7 +1770,7 @@ def parse_options() :
                     'encoding' : None }
 
         else :
-            print OPTPARSE_WARNING
+            print(OPTPARSE_WARNING)
             return None
 
     parser = optparse.OptionParser(usage="%prog INPUTFILE [options]")

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -111,11 +111,9 @@ class FootnoteExtension (markdown.Extension):
         ol = doc.createElement("ol")
         div.appendChild(ol)
 
-        footnotes = [(self.used_footnotes[id], id)
-                     for id in self.footnotes.keys()]
-        footnotes.sort()
+        footnotes = sorted((self.used_footnotes[id], id) for id in self.footnotes)
 
-        for i, id in footnotes :
+        for i, id in footnotes:
             li = doc.createElement('li')
             li.setAttribute('id', self.makeFootnoteId(i))
 

--- a/infogami/utils/stats.py
+++ b/infogami/utils/stats.py
@@ -8,9 +8,12 @@ Here is an example usage:
 
 Currently this doesn't support nesting.    
 """
-import web
 import time
-from context import context
+
+import web
+
+from infogami.utils.context import context
+
 
 def _get_stats():
     if "stats" not in web.ctx:

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -2,9 +2,15 @@
 Useful datastructures.
 """
 
-import web
 import copy
-from UserDict import DictMixin
+
+import web
+
+try:
+    from collections import MutableMapping as DictMixin
+except ImportError:
+    from UserDict import DictMixin
+
 
 class OrderedDict(dict):
     """
@@ -13,7 +19,7 @@ class OrderedDict(dict):
     _reserved = ['_keys']
 
     def __init__(self, d={}, **kw):
-        self._keys = d.keys() + kw.keys()
+        self._keys = list(d.keys()) + list(kw.keys())
         dict.__init__(self, d, **kw)
 
     def __delitem__(self, key):
@@ -33,7 +39,7 @@ class OrderedDict(dict):
         try:
             return self[key]
         except KeyError:
-            raise AttributeError, key
+            raise AttributeError(key)
 
     def __setattr__(self, key, value):
         # special care special methods
@@ -46,7 +52,7 @@ class OrderedDict(dict):
         try:
             del self[key]
         except KeyError:
-            raise AttributeError, key
+            raise AttributeError(key)
 
     def clear(self):
         dict.clear(self)
@@ -68,7 +74,7 @@ class OrderedDict(dict):
 
     def update(self, d):
         for key in d.keys():
-            if not self.has_key(key):
+            if key not in self:
                 self._keys.append(key)
         dict.update(self, d)
 
@@ -96,7 +102,7 @@ class OrderedDict(dict):
         return self.iterkeys()
 
     def index(self, key):
-        if not self.has_key(key):
+        if key not in self:
             raise KeyError(key)
         return self._keys.index(key)
 
@@ -179,7 +185,7 @@ class ReadOnlyDict:
         try:
             return self._d[key]
         except KeyError:
-            raise AttributeError, key
+            raise AttributeError(key)
 
 class DictPile(DictMixin):
     """Pile of ditionaries. 
@@ -211,7 +217,7 @@ class DictPile(DictMixin):
             if key in d:
                 return d[key]
         else:
-            raise KeyError, key
+            raise KeyError(key)
     
     def keys(self):
         keys = set()

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -206,25 +206,39 @@ class DictPile(DictMixin):
     """
     def __init__(self, dicts=[]):
         self.dicts = dicts[:]
-        
+
+    def __len__(self):
+        return len(self.dicts)
+
+    def __iter__(self):
+        for i in self.dicts:
+            yield i
+
     def add_dict(self, d):
         """Adds d to the pile of dicts at the top.
         """
         self.dicts.append(d)
-        
+
+    def __setitem__(self, key, value):
+        self.dicts.__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self.dicts.__delitem__(key)
+
     def __getitem__(self, key):
         for d in self.dicts[::-1]:
             if key in d:
                 return d[key]
         else:
             raise KeyError(key)
-    
+
     def keys(self):
         keys = set()
         for d in self.dicts:
             keys.update(d.keys())
         return list(keys)
-            
+
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -208,7 +208,7 @@ class DictPile(DictMixin):
         self.dicts = dicts[:]
 
     def __len__(self):
-        return len(self.dicts)
+        return len(self.keys())
 
     def __iter__(self):
         for i in self.dicts:

--- a/infogami/utils/types.py
+++ b/infogami/utils/types.py
@@ -1,7 +1,8 @@
 """Maintains a registry of path pattern vs type names to guess type from path when a page is newly created.
 """
 import re
-import storage
+
+from infogami.utils import storage
 
 default_type = '/type/page'
 type_patterns = storage.OrderedDict()

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -1,21 +1,29 @@
+from __future__ import print_function
+
+import os
+import re
+
+try:
+    from url.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 import web
-import os
-import urllib
-import re
 
 import infogami
 from infogami.core.diff import simple_diff, better_diff
-from infogami.utils import i18n
+from infogami.utils import i18n, macro, stats, storage
+from infogami.utils.context import context
+from infogami.utils.flash import get_flash_messages, add_flash_message
 from infogami.utils.markdown import markdown, mdx_footnotes
+from infogami.utils.template import render, render_template, get_template
 
-from context import context
-from template import render, render_template, get_template
-
-import macro
-import storage
-from flash import get_flash_messages, add_flash_message
-import stats
+try:
+    basestring
+    unicode
+except NameError:
+    basestring = (str, )
+    unicode = str
 
 wiki_processors = []
 def register_wiki_processor(p):
@@ -69,7 +77,7 @@ web.template.Template.globals.update(dict(
   utf8=web.utf8,
   Dropdown = web.form.Dropdown,
   slice = slice,
-  urlencode = urllib.urlencode,
+  urlencode = urlencode,
   debug = web.debug,
   get_flash_messages=get_flash_messages,
   render_template=render_template,
@@ -190,7 +198,7 @@ def thinginput(value, property=None, **kw):
                 from infogami.core import db        
                 kw['expected_type'] = db.get_version(kw['expected_type'])
         else:
-            raise ValueError, "missing expected_type"
+            raise ValueError("missing expected_type")
         property = web.storage(kw)
     return unicode(render.input(thingify(property.expected_type, value), property))
 
@@ -267,7 +275,7 @@ def movefiles():
                 to = os.path.join(dest, f)
                 cp_r(frm, to)
         else:
-            print 'copying %s to %s' % (src, dest)
+            print('copying %s to %s' % (src, dest))
             shutil.copy(src, dest)
     
     static_dir = os.path.join(os.getcwd(), "static")
@@ -315,7 +323,7 @@ def movetypes():
             files = [os.path.join(path, f) for f in sorted(os.listdir(path)) if f.endswith(extension)]
             for f in files:
                 d = readfile(f)
-                print >> web.debug, 'moving types from', f
+                print('moving types from', f, file=web.debug)
                 if isinstance(d, list):
                     pages.extend(d)
                 else:
@@ -347,12 +355,12 @@ def move(dir, extension, recursive=False, readfunc=None):
     delegate.admin_login()
     result = web.ctx.site.save_many(pages, "install")
     for r in result:
-        print r
+        print(r)
 
 @infogami.action
 def write(filename):
     q = open(filename).read()
-    print web.ctx.site.write(q)
+    print(web.ctx.site.write(q))
     
 # this is not really the right place to move this, but couldn't find a better place than this.     
 def require_login(f):
@@ -367,7 +375,7 @@ def login_redirect(path=None):
     if path is None:
         path = web.ctx.fullpath
 
-    query = urllib.urlencode({"redirect":path})
+    query = urlencode({"redirect":path})
     raise web.seeother("/account/login?" + query)
 
 def permission_denied(error):

--- a/migration/migrate-0.4-0.5.py
+++ b/migration/migrate-0.4-0.5.py
@@ -1,5 +1,6 @@
 """Script to migrate data from 0.4 to 0.5
 """
+from __future__ import print_function
 from optparse import OptionParser
 import os, sys
 import web
@@ -80,7 +81,7 @@ def fix_property_keys():
         copy_
     """
     def fix_type(type, type_id):
-        print >> web.debug, 'fixing type', type
+        print('fixing type', type, file=web.debug)
         prefix, multiple_types = get_table_prefix(type)
         keys_table = prefix + "_keys"
         keys = dict((r.key, r.id) for r in db.query('SELECT * FROM ' + keys_table))
@@ -94,7 +95,7 @@ def fix_property_keys():
         #@@ Making id of property table more than max_id of datum_keys makes sure that this case never happen.
         id1 = db.query('SELECT max(id) as x FROM ' + keys_table)[0].x
         id2 = db.query('SELECT max(id) as x FROM property')[0].x
-        print >> web.debug, 'max ids', id1, id2
+        print('max ids', id1, id2, file=web.debug)
         if id1 > id2:
             db.query("SELECT setval('property_id_seq', $id1)", vars=locals())
         
@@ -105,7 +106,7 @@ def fix_property_keys():
         
         for d in ['str', 'int', 'float', 'boolean', 'ref']:
             table = prefix + '_' + d            
-            print >> web.debug, 'fixing', type, table
+            print('fixing', type, table, file=web.debug)
             for key in keys:
                 old_key_id = keys[key]
                 new_key_id = newkeys[key]
@@ -115,10 +116,10 @@ def fix_property_keys():
                     updated = db.update(table, key_id=new_key_id, where='key_id=$old_key_id', vars=locals())
                 
                 total_updated[key] = total_updated.get(key, 0) + updated
-                print >> web.debug, 'updated', updated
+                print('updated', updated, file=web.debug)
                 
         unused = [k for k in total_updated if total_updated[k] == 0]
-        print >> web.debug, 'unused', unused
+        print('unused', unused, file=web.debug)
         db.delete('property', where=web.sqlors('id =', [newkeys[k] for k in unused]))
                 
     primitive = ['/type/key', '/type/int', '/type/float', '/type/boolean', '/type/string', '/type/datetime']
@@ -158,7 +159,7 @@ def process_keys(table):
         + " GROUP BY type, key_id")
         
     for r in result:
-        print r
+        print(r)
         
 def fix_version_table():
     """Add transaction table and move columns from version table to transaction table."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+simplejson
+web.py==0.33; python_version < '3.0'
+web.py==0.40-dev1; python_version >= '3.0'

--- a/sample_run.py
+++ b/sample_run.py
@@ -1,6 +1,7 @@
 """
 Sample run.py
 """
+from __future__ import print_function
 import infogami
 
 ## your db parameters
@@ -32,7 +33,7 @@ if __name__ == "__main__":
 
     if '--schema' in sys.argv:
         from infogami.infobase.dbstore import Schema
-        print Schema().sql()
+        print(Schema().sql())
     elif '--createsite' in sys.argv:
         createsite()
     else:

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,4 +1,4 @@
-import webtest
+from . import webtest
 
 def suite():
     modules = ["test_doctests", "test_dbstore", "test_infobase"]

--- a/test/test_dbstore.py
+++ b/test/test_dbstore.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.insert(0, '.')
 
@@ -37,13 +38,13 @@ class DBStoreTest(InfobaseTestCase):
         store.save('/x', d)
 
         d = store.get('/x')._get_data()
-        print d
+        print(d)
 
         del d['title']
         d['body'] = 'bar'
         store.save('/x', d)
 
-        print store.get('/x')._get_data()
+        print(store.get('/x')._get_data())
 
 class SaveTest(InfobaseTestCase):
     def testSave(self):
@@ -57,7 +58,7 @@ class SaveTest(InfobaseTestCase):
         try:
             key = d['key']
             self.assertEquals(self.site.save(key, d), {'key': key, 'revision': 1})
-        except common.InfobaseException, e:
+        except common.InfobaseException as e:
             self.assertEquals(str(e), error)
     
     def test_type(self):

--- a/test/test_doctests.py
+++ b/test/test_doctests.py
@@ -1,6 +1,6 @@
 """Run all doctests in infogami.
 """
-import webtest
+from . import webtest
 
 def suite():
     modules = [

--- a/test/test_infobase.py
+++ b/test/test_infobase.py
@@ -16,6 +16,12 @@ import web
 from infogami.infobase import server
 
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+
 def browser():
     if web.config.get('test_url'):
         b = web.browser.Browser()
@@ -32,7 +38,7 @@ def request(path, method="GET", data=None, headers={}):
         data = None
     if isinstance(data, dict):
         data = simplejson.dumps(data)
-    url = urllib.basejoin(b.url, path)
+    url = urljoin(b.url, path)
     req = url_request(url, data, headers)
     req.get_method = lambda: method
     b.do_request(req)

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -4,7 +4,8 @@ import doctest, unittest
 def add_doctests(suite):
     """create one test_xx function in globals for each doctest in the given module.
     """
-    suite = web.test.make_doctest_suite()
+    #suite = web.test.make_doctest_suite()
+    suite = doctest.DocTestSuite()
 
     add_test(make_suite(module))
 
@@ -35,5 +36,6 @@ modules = [
     "infogami.infobase.utils",
     "infogami.infobase.writequery",
 ]
-suite = web.test.doctest_suite(modules)
+#suite = web.test.doctest_suite(modules)
+suite = doctest.DocTestSuite()
 add_test(suite)

--- a/tests/test_infogami/test_account.py
+++ b/tests/test_infogami/test_account.py
@@ -12,7 +12,7 @@ def test_login():
 
     try:
         b.submit() 
-    except web.BrowserError, e:
+    except web.BrowserError as e:
         assert str(e) == 'Invalid username or password'
     else:
         assert False, 'Expected exception'

--- a/tests/test_infogami/test_pages.py
+++ b/tests/test_infogami/test_pages.py
@@ -34,7 +34,7 @@ def test_delete():
     b.select_form(name="edit")
     try:
         b.submit(name="_delete")
-    except web.BrowserError, e:
+    except web.BrowserError as e:
         pass
     else:
         assert False, "expected 404"


### PR DESCRIPTION
Hi @cclauss, this builds upon your PR https://github.com/internetarchive/infogami/pull/5 and tries to get the Travis tests passing. It's not complete, and I'm not 100% sure I haven't broken other stuff, but this is what I've come up with in trying to investigate what is needed to bring Infogami towards Python3 so we can move forward with Open Library. Hopefully there is something useful in here.

I'm happy to raise this PR to another branch if you want to collaborate further and see if we can get a fully working version.

* I seem to have fixed the `E   TypeError: Can't instantiate abstract class Render with abstract methods __delitem__, __iter__, __len__, __setitem__` errors on your PR's test run by adding methods to `DictMixin` as suggested by the comments here: https://stackoverflow.com/questions/11165188/how-to-achieve-the-functionality-of-userdict-dictmixin-in-python-3

* This PR also adds a working db to CI and gets the tests a bit further

Currently the Python 2.7 tests are failing on the following main updating issues:

* `NameError: global name 'urllib' is not defined`, in many places, which is hopefully a straight forward compatibility / update fix. I just haven't dug into it yet. I think you sorted similar issues in OL?

* A number of `ImportError: No module named ClientForm` , which I have not investigated either, but again I'm hoping it is another import-the-module-correctly change.

* The other failures look more subtle and may have more to do with Infogami than python. I'd suggest dealing with those later...