### PR TITLE
urllib.basejoin() was replaced by urljoin in Python 2.4

### DIFF
--- a/test/test_infobase.py
+++ b/test/test_infobase.py
@@ -5,6 +5,12 @@ import unittest
 import urllib, urllib2
 import simplejson
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+
 def browser():
     if web.config.get('test_url'):
         b = web.browser.Browser()
@@ -21,7 +27,7 @@ def request(path, method="GET", data=None, headers={}):
         data = None
     if isinstance(data, dict):
         data = simplejson.dumps(data)
-    url = urllib.basejoin(b.url, path)
+    url = urljoin(b.url, path)
     req = urllib2.Request(url, data, headers)
     req.get_method = lambda: method
     b.do_request(req)


### PR DESCRIPTION
https://github.com/python/cpython/commit/69200fa85b8825c52f05d54f1d6d3b58ea7fec6c