### PR TITLE
add a Travis CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # infogami
+[![Build Status](https://travis-ci.org/internetarchive/infogami.svg?branch=master)](https://travis-ci.org/internetarchive/infogami)
 
 The Open Library interface is powered by infogami -- a cleaner, simpler alternative to other wiki applications. But unlike other wikis, Infogami has the flexibility to handle different classes of data. Most wikis let you store unstructured pages -- big blocks of text. Infogami lets you store structured data.
 


### PR DESCRIPTION
This provides a link to the latest Travis CI results for the repo, showing Python 2.7 and 3.7 results and all the flake8 identified issues, so current and potential contributors can quickly see what needs to be done to enable Python 3 compatibility. 