### PR TITLE
Resolve undeclared variables in test code

### DIFF
--- a/infogami/infobase/tests/test_account.py
+++ b/infogami/infobase/tests/test_account.py
@@ -5,15 +5,21 @@ from infogami.infobase import server, account, bootstrap, common
 
 import pytest
 
+
 def setup_module(mod):
     utils.setup_site(mod)
+
 
 def teardown_module(mod):
     site.cache.clear()
     utils.teardown_site(mod)
 
+
 class TestAccount:
+    global site
+
     def setup_method(self, method):
+        global db
         self.tx = db.transaction()
 
     def teardown_method(self, method):

--- a/infogami/infobase/tests/test_client.py
+++ b/infogami/infobase/tests/test_client.py
@@ -4,6 +4,7 @@ from infogami.infobase import client, server
 
 import utils
 
+
 def setup_module(mod):
     utils.setup_conn(mod)
     utils.setup_server(mod)
@@ -12,9 +13,11 @@ def setup_module(mod):
     mod.s = mod.site.store
     mod.seq = mod.site.seq
 
+
 def teardown_module(mod):
     utils.teardown_server(mod)
     utils.teardown_conn(mod)
+
 
 class TestRecentChanges:
     def save_doc(self, key, **kw):
@@ -68,6 +71,9 @@ class TestRecentChanges:
         assert [c['data'] for c in changes] == [{"x": "two"}]
 
 class TestStore:
+    global site
+    global s  # site.store
+
     def setup_method(self, method):
         s.clear()
 
@@ -162,6 +168,7 @@ class TestStore:
 
 class TestSeq:
     def test_seq(self):
+        global seq
         seq.get_value("foo") == 0
         seq.get_value("bar") == 0
 
@@ -177,6 +184,7 @@ class TestSanity:
 class TestAccount:
     """Test account creation, forgot password etc."""
     def test_register(self):
+        global site
         email = "joe@example.com"
         response = site.register(username="joe", displayname="Joe", email=email, password="secret")
 

--- a/infogami/infobase/tests/test_read.py
+++ b/infogami/infobase/tests/test_read.py
@@ -7,11 +7,14 @@ import utils
 
 import datetime
 
+
 def setup_module(mod):
     utils.setup_db(mod)
 
+
 def teardown_module(mod):
     utils.teardown_db(mod)
+
 
 class DBTest:
     def setup_method(self, method):
@@ -20,6 +23,7 @@ class DBTest:
 
     def teardown_method(self, method):
         self.tx.rollback()
+
 
 class TestRecentChanges(DBTest):
     def _save(self, docs, author=None, ip="1.2.3.4", comment="testing", kind="test_save", timestamp=None, data=None):
@@ -183,6 +187,7 @@ class TestRecentChanges(DBTest):
         self.save_doc("/b", kind="bar", timestamp=date("2010-01-03"), comment="b")
 
         def changes(**kw):
+            global db
             return [c['comment'] for c in RecentChanges(db).recentchanges(**kw)]
 
         # begin_date is included in the interval, but end_date is not included.

--- a/infogami/infobase/tests/test_read.py
+++ b/infogami/infobase/tests/test_read.py
@@ -27,7 +27,7 @@ class DBTest:
 
 class TestRecentChanges(DBTest):
     def _save(self, docs, author=None, ip="1.2.3.4", comment="testing", kind="test_save", timestamp=None, data=None):
-        timestamp = timestamp=timestamp or datetime.datetime(2010, 01, 02, 03, 04, 05)
+        timestamp = timestamp=timestamp or datetime.datetime(2010, 1, 2, 3, 4, 5)
         s = SaveImpl(db)
         s.save(docs, 
             timestamp=timestamp,
@@ -58,7 +58,7 @@ class TestRecentChanges(DBTest):
             {"key": "/foo", "type": {"key": "/type/object"}, "title": "foo"},
             {"key": "/bar", "type": {"key": "/type/object"}, "title": "bar"}
         ]
-        timestamp = datetime.datetime(2010, 01, 02, 03, 04, 05)
+        timestamp = datetime.datetime(2010, 1, 2, 3, 4, 5)
         self._save(docs, comment="testing recentchanges", timestamp=timestamp)
 
         engine = RecentChanges(db)

--- a/infogami/infobase/tests/test_save.py
+++ b/infogami/infobase/tests/test_save.py
@@ -62,7 +62,7 @@ class Test_get_records_for_save(DBTest):
     """
     def test_new(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
 
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         b = {"key": "/b", "type": {"key": "/type/object"}, "title": "b"}
@@ -79,12 +79,12 @@ class Test_get_records_for_save(DBTest):
             id = db.insert('thing', key=doc['key'], latest_revision=revision, created=created, last_modified=last_modified)
             db.insert('data', seqname=False, thing_id=id, revision=revision, data=simplejson.dumps(doc))
 
-        created = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        created = datetime.datetime(2010, 1, 1, 1, 1, 1)
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         insert(a, 1, created, created)
 
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 02, 02, 02, 02, 02)
+        timestamp = datetime.datetime(2010, 2, 2, 2, 2, 2)
         records = s._get_records_for_save([a], timestamp)
 
         assert_record(records[0], a, 2, created, timestamp)
@@ -97,7 +97,7 @@ class Test_save(DBTest):
 
     def test_save(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
 
         status = s.save(
@@ -112,7 +112,7 @@ class Test_save(DBTest):
         assert self.get_json('/a') == update_doc(a, 1, timestamp, timestamp)
 
         a['title'] = 'b'
-        timestamp2 = datetime.datetime(2010, 02, 02, 02, 02, 02)
+        timestamp2 = datetime.datetime(2010, 2, 2, 2, 2, 2)
         status = s.save(
                     [a],
                     timestamp=timestamp2,
@@ -125,7 +125,7 @@ class Test_save(DBTest):
 
     def test_type_change(self):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         a = {"key": "/a", "type": {"key": "/type/object"}, "title": "a"}
         status = s.save(
                     [a],
@@ -139,7 +139,7 @@ class Test_save(DBTest):
         type_delete_id = db.insert("thing", key='/type/delete')
         a['type']['key'] = '/type/delete'
 
-        timestamp2 = datetime.datetime(2010, 02, 02, 02, 02, 02)
+        timestamp2 = datetime.datetime(2010, 2, 2, 2, 2, 2)
         status = s.save(
                     [a],
                     timestamp=timestamp2,
@@ -182,7 +182,7 @@ class Test_save(DBTest):
 
     def _save(self, docs):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         return s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
 
     def test_save_with_new_type(self):
@@ -194,7 +194,7 @@ class Test_save(DBTest):
             "type": {"key": "/type/foo"}
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
 
         s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
 
@@ -221,7 +221,7 @@ class Test_save(DBTest):
             "title": "a" * 4000
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
 
     def test_transaction(self, wildcard):
@@ -230,7 +230,7 @@ class Test_save(DBTest):
             "type": {"key": "/type/object"},
         }]
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         changeset = s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
         changeset.pop("docs")
         changeset.pop("old_docs")
@@ -407,7 +407,7 @@ class TestIndex:
 class TestIndexWithDB(DBTest):
     def _save(self, docs):
         s = SaveImpl(db)
-        timestamp = datetime.datetime(2010, 01, 01, 01, 01, 01)
+        timestamp = datetime.datetime(2010, 1, 1, 1, 1, 1)
         return s.save(docs, timestamp=timestamp, comment="foo", ip="1.2.3.4", author=None, action="save")
 
     def test_reindex(self):
@@ -425,7 +425,7 @@ class TestIndexWithDB(DBTest):
         for i in range(10):
             db.insert("datum_str", thing_id=thing.id, key_id=key_id, value="foo %d" % i)
 
-        # verify that the bad enties are added
+        # verify that the bad entries are added
         d = db.query("SELECT * FROM datum_str WHERE thing_id=$thing.id AND key_id=$key_id", vars=locals())
         assert len(d) == 11
 
@@ -466,7 +466,7 @@ class TestPropertyManager(DBTest):
         p2 = p.copy()
         assert p2.get_property_id("/type/object", "title") == pid
 
-        # changes to the cache of the copy shouldn't effect the source.
+        # changes to the cache of the copy shouldn't affect the source.
         tx = db.transaction()
         p2.get_property_id("/type/object", "title2", create=True)
         tx.rollback()

--- a/infogami/infobase/tests/test_seq.py
+++ b/infogami/infobase/tests/test_seq.py
@@ -4,23 +4,28 @@ import utils
 import unittest
 import simplejson
 
+
 def setup_module(mod):
+    global db
     utils.setup_db(mod)
     mod.seq = SequenceImpl(db)
+
 
 def teardown_module(mod):
     utils.teardown_db(mod)
     mod.seq = None
 
+
 class TestSeq:
     def setup_method(self, method):
+        global db
         db.delete("seq", where="1=1")
 
     def test_seq(self):
+        global seq
         seq.get_value("foo") == 0
         seq.next_value("foo") == 1
         seq.get_value("foo") == 1
 
         seq.next_value("foo") == 2
         seq.next_value("foo") == 3
-

--- a/infogami/infobase/tests/test_store.py
+++ b/infogami/infobase/tests/test_store.py
@@ -23,6 +23,8 @@ class DBTest:
         self.tx.rollback()
 
 class TestStore(DBTest):
+    global store
+
     def test_insert(self, wildcard):
         for i in range(10):
             d = {"name": str(i), "value": i}
@@ -146,6 +148,7 @@ class TestStore(DBTest):
         assert f({"name": "foo"}) == [("name", "foo")]
 
     def test_typewise_indexer2(self):
+        global db
         s = Store(db)
         s.indexer = TypewiseIndexer()
         s.indexer.set_indexer("book", BookIndexer())
@@ -168,6 +171,7 @@ class TestStore(DBTest):
         assert store.query(None, None, None) == [{"key": "x"}]
         assert store.query("", None, None) == [{"key": "x"}]
         assert store.query("", "name", "foo") == [{"key": "x"}]
+
 
 class BookIndexer:
     def index(self, doc):

--- a/infogami/infobase/tests/test_writequery.py
+++ b/infogami/infobase/tests/test_writequery.py
@@ -3,6 +3,7 @@ import web
 import utils
 from .. import common, writequery
 
+
 def setup_module(mod):
     utils.setup_site(mod)
 
@@ -54,18 +55,25 @@ def setup_module(mod):
     }
     mod.site.save_many([type_book, type_author, type_link])
 
+
 def teardown_module(mod):
     utils.teardown_site(mod)
 
+
 class DBTest:
     def setup_method(self, method):
+        global db
         self.tx = db.transaction()
 
     def teardown_method(self, method):
         self.tx.rollback()
 
+
 class TestSaveProcessor(DBTest):
+    global site
+
     def test_errors(self):
+
         def save_many(query):
             try:
                 site.save_many(query)
@@ -83,8 +91,8 @@ class TestSaveProcessor(DBTest):
             "name": ["a", "b"]
         }
         assert save_many([q]) == {
-            'error': 'bad_data', 
-            'message': 'expected atom, found list', 
+            'error': 'bad_data',
+            'message': 'expected atom, found list',
             'at': {'key': '/authors/1', 'property': 'name'},
             'value': ['a', 'b']
         }
@@ -95,8 +103,8 @@ class TestSaveProcessor(DBTest):
             "name": 123
         }
         assert save_many([q]) == {
-            'error': 'bad_data', 
-            'message': 'expected /type/string, found /type/int', 
+            'error': 'bad_data',
+            'message': 'expected /type/string, found /type/int',
             'at': {'key': '/authors/1', 'property': 'name'},
             "value": 123
         }
@@ -113,10 +121,11 @@ class TestSaveProcessor(DBTest):
             "type": "/type/book",
             "publish_year": "not-int"
         }
-        assert save_many([q]) == {'error': 'bad_data', 
-            'message': "invalid literal for int() with base 10: 'not-int'", 
+        assert save_many([q]) == {
+            'error': 'bad_data',
+            'message': "invalid literal for int() with base 10: 'not-int'",
             'at': {
-                'key': '/books/1', 
+                'key': '/books/1',
                 'property': 'publish_year'
             },
             "value": "not-int"
@@ -128,10 +137,10 @@ class TestSaveProcessor(DBTest):
             "links": ["foo"]
         }
         assert save_many([q]) == {
-            'error': 'bad_data', 
-            'message': 'expected /type/link, found /type/string', 
+            'error': 'bad_data',
+            'message': 'expected /type/link, found /type/string',
             'at': {
-                'key': '/books/1', 
+                'key': '/books/1',
                 'property': 'links'
             },
             'value': 'foo'
@@ -143,10 +152,10 @@ class TestSaveProcessor(DBTest):
             "links": [{"title": 1}]
         }
         assert save_many([q]) == {
-            'error': 'bad_data', 
+            'error': 'bad_data',
             'message': 'expected /type/string, found /type/int',
             'at': {
-                'key': '/books/1', 
+                'key': '/books/1',
                 'property': 'links.title'
             },
             'value': 1

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,6 +1,6 @@
-import doctest
 import unittest
 from web.test import doctest_suite
+
 
 def add_test(test):
     if isinstance(test, unittest.TestSuite):
@@ -8,12 +8,12 @@ def add_test(test):
             add_test(t)
     elif isinstance(test, unittest.TestCase):
         test_method = getattr(test, test._testMethodName)
+
         def do_test(test_method=test_method):
             test_method()
         name = "test_" + test.id().replace(".", "_")
         globals()[name] = do_test
-    else:
-        doom
+
 
 modules = [
     "infogami.core.code",
@@ -29,5 +29,7 @@ modules = [
     "infogami.infobase.utils",
     "infogami.infobase.writequery",
 ]
+
 suite = doctest_suite(modules)
+
 add_test(suite)

--- a/tests/test_infogami/__init__.py
+++ b/tests/test_infogami/__init__.py
@@ -1,13 +1,8 @@
-import sys, os
-dir = os.path.abspath(os.path.dirname(__file__) + "/..")
-sys.path.append(dir)
-
+import os
 import web
 import infogami
 from infogami.infobase import server
 from infogami.utils.delegate import app
-
-import os
 
 # overwrite _cleanup to stop clearing thread state between requests
 app._cleanup = lambda *a: None
@@ -21,22 +16,24 @@ def setup_module(module):
     infogami.config.site = "infogami.org"
     infogami.config.db_parameters = web.config.db_parameters = db_parameters
 
-    server.get_site("infogami.org") # to initialize db
+    server.get_site("infogami.org")  # to initialize db
 
     module.db = server._infobase.store.db
     module.db.printing = False
-    module.t = db.transaction()
+    module.t = module.db.transaction()
 
     infogami._setup()
+
 
 def teardown_module(module):
     module.t.rollback()
 
+
 def monkey_patch_browser():
     def check_errors(self):
         errors = [self.get_text(e) for e in
-            self.get_soup().findAll(attrs={'id': 'error'}) +
-            self.get_soup().findAll(attrs={'class': 'wrong'})]
+                  self.get_soup().findAll(attrs={'id': 'error'}) +
+                  self.get_soup().findAll(attrs={'class': 'wrong'})]
         if errors:
             raise web.BrowserError(errors[0])
 
@@ -51,5 +48,3 @@ def monkey_patch_browser():
 
     web.AppBrowser.do_request = do_request
     web.AppBrowser.check_errors = check_errors
-
-


### PR DESCRIPTION
This PR reduces the number of flake8 undeclared variable warnings (F821) in the tests directory by declaring all the module level variable set by test setup methods in https://github.com/internetarchive/infogami/blob/master/infogami/infobase/tests/utils.py by simply declaring them using the `global` keyword at either the test class level if the var is used all through the class, or at the test/function level if it is only used in one.

`flake8 infogami/infobase/tests --count --exit-zero --select=F821 --show-source --statistics`

The 'proper' solution would be to avoid this use of globals by rewriting all of the tests to use pytest fixtures (which didn't exist when these tests were written), but I don't want to dig into the specific db setup details, and the current method works.

With the test module level variable warnings out of the way, there are very few remaining undeclared variables in the code.