### PR TITLE
Fix up imports for Python3 compatibility on the tests

### DIFF
--- a/infogami/__init__.py
+++ b/infogami/__init__.py
@@ -4,8 +4,9 @@ from __future__ import print_function
 __version__ = "0.5dev"
 
 import web
-import config
 import sys
+from infogami import config
+
 
 usage = """
 Infogami

--- a/infogami/infobase/__init__.py
+++ b/infogami/infobase/__init__.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import sys
 import web
 
-import config, infobase, logger, logreader
+from infogami.infobase import config, infobase, logger, logreader
 
 commands = {}
 def command(f):

--- a/infogami/infobase/common.py
+++ b/infogami/infobase/common.py
@@ -1,8 +1,8 @@
-import config
 import web
 
-from core import *
-from utils import *
+from infogami.infobase import config
+from infogami.infobase.core import *
+from infogami.infobase.utils import *
 
 # Primitive types and corresponding python types
 primitive_types = {

--- a/infogami/infobase/core.py
+++ b/infogami/infobase/core.py
@@ -1,9 +1,11 @@
 """Core datastructures for Infogami.
 """
 import web
-import _json as simplejson
 import copy
 from six import text_type
+
+from infogami.infobase import _json as simplejson
+
 
 class InfobaseException(Exception):
     status = "500 Internal Server Error"
@@ -19,21 +21,25 @@ class InfobaseException(Exception):
     def dict(self):
         return dict(self.d)
 
+
 class NotFound(InfobaseException):
     status = "404 Not Found"
     def __init__(self, **kw):
         error = kw.pop('error', 'notfound')
         InfobaseException.__init__(self, error=error, **kw)
 
+
 class UserNotFound(InfobaseException):
     status = "404 Not Found"
     def __init__(self, **kw):
         InfobaseException.__init__(self, error='user_notfound', **kw)
 
+
 class PermissionDenied(InfobaseException):
     status = "403 Forbidden"
     def __init__(self, **kw):
         InfobaseException.__init__(self, error='permission_denied', **kw)
+
 
 class BadData(InfobaseException):
     status = "400 Bad Request"
@@ -41,25 +47,30 @@ class BadData(InfobaseException):
     def __init__(self, **kw):
         InfobaseException.__init__(self, error='bad_data', **kw)
 
+
 class Conflict(InfobaseException):
     status = "409 Conflict"
 
     def __init__(self, **kw):
         InfobaseException.__init__(self, error="conflict", **kw)
 
+
 class TypeMismatch(BadData):
     def __init__(self, type_expected, type_found, **kw):
         BadData.__init__(self, message="expected %s, found %s" % (type_expected, type_found), **kw)
+
 
 class Text(text_type):
     """Python type for /type/text."""
     def __repr__(self):
         return "<text: %s>" % text_type.__repr__(self)
 
+
 class Reference(text_type):
     """Python type for reference type."""
     def __repr__(self):
         return "<ref: %s>" % text_type.__repr__(self)
+
 
 class Thing:
     def __init__(self, store, key, data):
@@ -130,6 +141,7 @@ class Thing:
         data = common.parse_query(data)
         return Thing(store, key, data)
 
+
 class Store:
     """Storage for Infobase.
 
@@ -146,6 +158,7 @@ class Store:
     def delete(self, sitename):
         """Deletes the store for the specified sitename."""
         raise NotImplementedError
+
 
 class SiteStore:
     """Interface for Infobase data storage"""
@@ -203,6 +216,7 @@ class SiteStore:
 
     def set_cache(self, cache):
         pass
+
 
 class Event:
     """Infobase Event.

--- a/infogami/infobase/infobase.py
+++ b/infogami/infobase/infobase.py
@@ -9,13 +9,11 @@ import web
 import datetime
 import simplejson
 
-import common
-import config
-import readquery
-import writequery
+from infogami.infobase import common, config, readquery, writequery
 
 # important: this is required here to setup _loadhooks and unloadhooks
-import cache
+from infogami.infobase import cache
+
 
 class Infobase:
     """Infobase contains multiple sites."""
@@ -69,6 +67,7 @@ class Infobase:
             except:
                 common.record_exception()
                 pass
+
 
 class Site:
     """A site of infobase."""

--- a/infogami/infobase/readquery.py
+++ b/infogami/infobase/readquery.py
@@ -1,8 +1,9 @@
-import common
-from common import all, any
 import web
 import re
 import _json as simplejson
+
+from infogami.infobase import common
+from infogami.infobase.common import all, any
 
 def get_thing(store, key, revision=None):
     json = key and store.get(key, revision)


### PR DESCRIPTION
Latest tests fail on this code:
```
infogami/infobase/core.py:61: in <module>
    class Text(unicode):
E   NameError: name 'unicode' is not defined
```
https://travis-ci.org/hornc/infogami/jobs/577183152

Which is the subject of the comment in #39 to be done in another PR.

This was done as a quick experiment to see what was required to at least get the tests loading in Python 3. #39 should perhaps be merged first, I don't think there are conflicts, but #39 was first, and this will be easier to redo. 