### PR TITLE
DictMixin to collections.abc.mapping

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -929,7 +929,6 @@ register_thing_class('/type/type', Type)
 hooks = []
 class metahook(type):
     def __init__(self, name, bases, attrs):
-        global hooks
         hooks.append(self())
         type.__init__(self, name, bases, attrs)
 

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -929,6 +929,7 @@ register_thing_class('/type/type', Type)
 hooks = []
 class metahook(type):
     def __init__(self, name, bases, attrs):
+        global hooks
         hooks.append(self())
         type.__init__(self, name, bases, attrs)
 

--- a/infogami/plugins/wikitemplates/code.py
+++ b/infogami/plugins/wikitemplates/code.py
@@ -5,11 +5,9 @@ from __future__ import print_function
 
 import os
 try:
-    from UserDict import DictMixin
+    from collections.abc import Mapping
 except ImportError:
-    from collections import MutableMapping as DictMixin
-
-import web
+    from collections import Mapping
 
 import web
 
@@ -25,7 +23,7 @@ from infogami.utils.view import require_login
 
 LazyTemplate = template.LazyTemplate
 
-class WikiSource(DictMixin):
+class WikiSource(Mapping):
     """Template source for templates in the wiki"""
     def __init__(self, templates):
         self.templates = templates

--- a/infogami/plugins/wikitemplates/code.py
+++ b/infogami/plugins/wikitemplates/code.py
@@ -4,7 +4,12 @@ wikitemplates: allow keeping templates and macros in wiki
 from __future__ import print_function
 
 import os
-from UserDict import DictMixin
+try:
+    from UserDict import DictMixin
+except ImportError:
+    from collections import MutableMapping as DictMixin
+
+import web
 
 import web
 

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -5,9 +5,9 @@ Useful datastructures.
 import copy
 from collections import defaultdict, OrderedDict
 try:
-    from UserDict import DictMixin
+    from collections.abc import Mapping
 except ImportError:
-    from collections import MutableMapping as DictMixin
+    from collections import Mapping
 
 import web
 
@@ -57,7 +57,7 @@ class ReadOnlyDict:
         except KeyError:
             raise AttributeError(key)
 
-class DictPile(DictMixin):
+class DictPile(Mapping):
     """Pile of ditionaries.
     A key in top dictionary covers the key with the same name in the bottom dictionary.
 

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -64,6 +64,10 @@ class DictPile(Mapping):
         >>> a = {'x': 1, 'y': 2}
         >>> b = {'y': 5, 'z': 6}
         >>> d = DictPile([a, b])
+        >>> len(d)
+        3
+        >>> list(iter(d)) == d.keys()
+        True
         >>> d['x'], d['y'], d['z']
         (1, 5, 6)
         >>> b['x'] = 4
@@ -73,6 +77,15 @@ class DictPile(Mapping):
         >>> d.add_dict(c)
         >>> d['x'], d['y'], d['z']
         (0, 1, 6)
+        >>> d.add_dict({'new': 99})
+        >>> len(d)
+        4
+        >>> list(iter(d)) == d.keys()
+        True
+        >>> 'new' in d
+        True
+        >>> 'nope' in d
+        False
     """
     def __init__(self, dicts=[]):
         self.dicts = dicts[:]
@@ -89,11 +102,18 @@ class DictPile(Mapping):
         else:
             raise KeyError(key)
 
+    def __iter__(self):
+        return (key for key in self.keys())
+
+    def __len__(self):
+        return len(self.keys())
+
     def keys(self):
         keys = set()
         for d in self.dicts:
             keys.update(d.keys())
         return list(keys)
+
 
 if __name__ == "__main__":
     import doctest

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -4,12 +4,15 @@ Useful datastructures.
 
 import copy
 from collections import defaultdict, OrderedDict
-from UserDict import DictMixin
+try:
+    from UserDict import DictMixin
+except ImportError:
+    from collections import MutableMapping as DictMixin
 
 import web
 
-
 storage = defaultdict(OrderedDict)
+
 
 class SiteLocalDict:
     """

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -103,7 +103,8 @@ class DictPile(Mapping):
             raise KeyError(key)
 
     def __iter__(self):
-        return (key for key in self.keys())
+        for key in self.keys():
+            yield key
 
     def __len__(self):
         return len(self.keys())

--- a/infogami/utils/template.py
+++ b/infogami/utils/template.py
@@ -17,13 +17,14 @@ from infogami.utils import storage
 
 # There are some backward-incompatible changes in web.py 0.34 which makes Infogami fail.
 # Monkey-patching web.py to fix that issue.
-if web.__version__ == "0.34":
-    try:
-        from UserDict import DictMixin
-    except ImportError:
-        from collections import MutableMapping as DictMixin
-    web.template.TemplateResult.__bases__ = (DictMixin, web.storage)
-    web.template.StatementNode.emit = lambda self, indent, text_indent="": indent + self.stmt
+assert web.__version__ != "0.34",  "Please pip install --upgrade web.py"
+#if web.__version__ == "0.34":
+#    try:
+#        from UserDict import DictMixin
+#    except ImportError:
+#        from collections import MutableMapping as DictMixin
+#    web.template.TemplateResult.__bases__ = (DictMixin, web.storage)
+#    web.template.StatementNode.emit = lambda self, indent, text_indent="": indent + self.stmt
 
 web_render = web.template.render
 

--- a/infogami/utils/template.py
+++ b/infogami/utils/template.py
@@ -16,16 +16,7 @@ import web
 from infogami.utils import storage
 
 # There are some backward-incompatible changes in web.py 0.34 which makes Infogami fail.
-# Monkey-patching web.py to fix that issue.
 assert web.__version__ != "0.34",  "Please pip install --upgrade web.py"
-#if web.__version__ == "0.34":
-#    try:
-#        from UserDict import DictMixin
-#    except ImportError:
-#        from collections import MutableMapping as DictMixin
-#    web.template.TemplateResult.__bases__ = (DictMixin, web.storage)
-#    web.template.StatementNode.emit = lambda self, indent, text_indent="": indent + self.stmt
-
 web_render = web.template.render
 
 class TemplateRender(web_render):

--- a/infogami/utils/template.py
+++ b/infogami/utils/template.py
@@ -18,7 +18,10 @@ from infogami.utils import storage
 # There are some backward-incompatible changes in web.py 0.34 which makes Infogami fail.
 # Monkey-patching web.py to fix that issue.
 if web.__version__ == "0.34":
-    from UserDict import DictMixin
+    try:
+        from UserDict import DictMixin
+    except ImportError:
+        from collections import MutableMapping as DictMixin
     web.template.TemplateResult.__bases__ = (DictMixin, web.storage)
     web.template.StatementNode.emit = lambda self, indent, text_indent="": indent + self.stmt
 


### PR DESCRIPTION
Fixes #44 based on the discussion at http://python3porting.com/problems.html#replacing-userdict

* ~Declares __global hooks__ for clarity vs. scoping rules.~
* ~Use __list(dict)__ instead of __dict.keys()__ for Python 3.~
* ~Fix more imports.~
* ~__futurize -f lib2to3.fixes.fix_has_key -w .__~

~The Python 2 test continue to pass and this PR is ready to be reviewed and landed.~

~However, on Python 3 there are 15 errors but all these errors all boil down to just three root causes.~  **help needed** to fix these so we can continue to progress.

@anandology Some of this code is beyond me so any pointers would be gratefully received.