### PR TITLE
web.py has deprecated web.utf8() in favor of web.safestr()

### DIFF
--- a/infogami/infobase/account.py
+++ b/infogami/infobase/account.py
@@ -207,7 +207,7 @@ class AccountManager:
 
     def _generate_salted_hash(self, key, text, salt=None):
         salt = salt or hmac.HMAC(key, str(random.random())).hexdigest()[:5]
-        hash = hmac.HMAC(key, web.utf8(salt) + web.utf8(text)).hexdigest()
+        hash = hmac.HMAC(key, web.safestr(salt) + web.safestr(text)).hexdigest()
         return '%s$%s' % (salt, hash)
 
     def _check_salted_hash(self, key, text, salted_hash):

--- a/infogami/infobase/bulkupload.py
+++ b/infogami/infobase/bulkupload.py
@@ -78,7 +78,7 @@ def multiple_insert(table, values, seqname=None):
 
     def write(path, data):
         f = open(path, 'w')
-        f.write(web.utf8(data))
+        f.write(web.safestr(data))
         f.close()
 
     if not values:

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -641,7 +641,7 @@ class Nothing:
     >>> n = Nothing()
     >>> str(n)
     ''
-    >>> web.utf8(n)
+    >>> web.safestr(n)
     ''
     """
     def __getattr__(self, name):
@@ -843,7 +843,7 @@ class Thing:
         return not self.__eq__(other)
 
     def __str__(self):
-        return web.utf8(self.key)
+        return web.safestr(self.key)
 
     def __repr__(self):
         if self.key:

--- a/infogami/plugins/wikitemplates/code.py
+++ b/infogami/plugins/wikitemplates/code.py
@@ -3,21 +3,20 @@ wikitemplates: allow keeping templates and macros in wiki
 """
 from __future__ import print_function
 
-import web
 import os
 from UserDict import DictMixin
+
+import web
 
 import infogami
 from infogami import core, config
 from infogami.core.db import ValidationException
+from infogami.infobase import client
+from infogami.plugins.wikitemplates import db
 from infogami.utils import delegate, macro, template, storage, view
 from infogami.utils.context import context
 from infogami.utils.template import render
 from infogami.utils.view import require_login
-
-from infogami.infobase import client
-
-import db
 
 LazyTemplate = template.LazyTemplate
 
@@ -36,7 +35,7 @@ class WikiSource(DictMixin):
             raise KeyError(key)
 
         root = web.rstrips(root or "", "/")
-        value = self.templates[root + key]    
+        value = self.templates[root + key]
         if isinstance(value, LazyTemplate):
             value = value.func()
 
@@ -96,7 +95,7 @@ class hooks(client.hook):
     def on_new_version(self, page):
         """Updates the template/macro cache, when a new version is saved or deleted."""
         if page.type.key == '/type/template':
-            _load_template(page)            
+            _load_template(page)
         elif page.type.key == '/type/macro':
             _load_macro(page)
         elif page.type.key == '/type/delete':
@@ -148,7 +147,7 @@ def _load_macro(page, lazy=False):
         wikimacros[page.key] = t
 
 def load_all():
-    def load_macros(site): 
+    def load_macros(site):
         for m in db.get_all_macros(site):
             _load_macro(m, lazy=True)
 

--- a/infogami/utils/i18n.py
+++ b/infogami/utils/i18n.py
@@ -39,8 +39,8 @@ class i18n:
         return i18n_namespace(self, namespace)
 
     def getkeys(self, namespace, lang=None):
-        namespace = web.utf8(namespace)
-        lang = web.utf8(lang)
+        namespace = web.safestr(namespace)
+        lang = web.safestr(lang)
 
         # making a simplified assumption here.
         # Keys for a language are all the strings defined for that language and
@@ -50,18 +50,18 @@ class i18n:
         return sorted(keys)
 
     def _set_strings(self, namespace, lang, data):
-        namespace = web.utf8(namespace)
-        lang = web.utf8(lang)
+        namespace = web.safestr(namespace)
+        lang = web.safestr(lang)
         self._data[namespace, lang] = dict(data)
 
     def _update_strings(self, namespace, lang, data):
-        namespace = web.utf8(namespace)
-        lang = web.utf8(lang)
+        namespace = web.safestr(namespace)
+        lang = web.safestr(lang)
         self._data.setdefault((namespace, lang), {}).update(data)
 
     def get(self, namespace, key):
-        namespace = web.utf8(namespace)
-        key = web.utf8(key)
+        namespace = web.safestr(namespace)
+        key = web.safestr(key)
         return i18n_string(self, namespace, key)
 
     def __getattr__(self, key):
@@ -72,7 +72,7 @@ class i18n:
 
     def __getitem__(self, key):
         namespace = web.ctx.get('i18n_namespace', '/')
-        key = web.utf8(key)
+        key = web.safestr(key)
         return i18n_string(self, namespace, key)
 
 class i18n_namespace:
@@ -101,12 +101,12 @@ class i18n_string:
         default_data = get(DEFAULT_LANG) or {}
         data = get(web.ctx.lang) or default_data
         text = data.get(self._key) or default_data.get(self._key) or self._key
-        return web.utf8(text)
+        return web.safestr(text)
 
     def __call__(self, *a):
         try:
             a = [x or "" for x in a]
-            return str(self) % tuple(web.utf8(x) for x in a)
+            return str(self) % tuple(web.safestr(x) for x in a)
         except:
             print('failed to substitute (%s/%s) in language %s' % (self._namespace, self._key, web.ctx.lang), file=web.debug)
         return str(self)

--- a/infogami/utils/macro.py
+++ b/infogami/utils/macro.py
@@ -44,7 +44,7 @@ def safeeval_args(args):
     def f(*args, **kwargs):
         result[0] = args, kwargs
     code = "$def with (f)\n$f(%s)" % args
-    web.template.Template(web.utf8(code))(f)
+    web.template.Template(web.safestr(code))(f)
     return result[0]
 
 def call_macro(name, args):
@@ -91,7 +91,7 @@ def replace_macros(html, macros):
     """Replaces the macro place holders with real macro output."""
     for placeholder, macro_info in macros.items():
         name, args = macro_info
-        html = html.replace("<p>%s\n</p>" % placeholder, web.utf8(call_macro(name, args)))
+        html = html.replace("<p>%s\n</p>" % placeholder, web.safestr(call_macro(name, args)))
 
     return html
 

--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -314,7 +314,7 @@ class Element :
         if self.nodeName in ['p', 'li', 'ul', 'ol',
                              'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] :
 
-            if not self.attribute_values.has_key("dir"):
+            if "dir" not in self.attribute_values:
                 if self.bidi :
                     bidi = self.bidi
                 else :
@@ -798,7 +798,7 @@ class ReferencePattern (Pattern):
             # we'll use "google" as the id
             id = m.group(2).lower()
 
-        if not self.references.has_key(id) : # ignore undefined refs
+        if id not in self.references : # ignore undefined refs
             return None
         href, title = self.references[id]
         text = m.group(2)
@@ -1138,7 +1138,7 @@ class Markdown:
                         % (ext, extension_module_name) )
             else :
 
-                if configs.has_key(ext) :
+                if ext in configs :
                     configs_for_ext = configs[ext]
                 else :
                     configs_for_ext = []
@@ -1733,7 +1733,7 @@ class Extension :
         self.config = configs
 
     def getConfig(self, key) :
-        if self.config.has_key(key) :
+        if key in self.config :
             return self.config[key][0]
         else :
             return ""

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -2,151 +2,24 @@
 Useful datastructures.
 """
 
-import web
 import copy
+from collections import defaultdict, OrderedDict
 from UserDict import DictMixin
 
-class OrderedDict(dict):
-    """
-    A dictionary in which the insertion order of items is preserved.
-    """
-    _reserved = ['_keys']
+import web
 
-    def __init__(self, d={}, **kw):
-        self._keys = d.keys() + kw.keys()
-        dict.__init__(self, d, **kw)
 
-    def __delitem__(self, key):
-        dict.__delitem__(self, key)
-        self._keys.remove(key)
-
-    def __setitem__(self, key, item):
-        # a peculiar sharp edge from copy.deepcopy
-        # we'll have our set item called without __init__
-        if not hasattr(self, '_keys'):
-            self._keys = [key,]
-        if key not in self:
-            self._keys.append(key)
-        dict.__setitem__(self, key, item)
-
-    def __getattr__(self, key):
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(key)
-
-    def __setattr__(self, key, value):
-        # special care special methods
-        if key in self._reserved:
-            self.__dict__[key] = value
-        else:
-            self[key] = value
-
-    def __delattr__(self, key):
-        try:
-            del self[key]
-        except KeyError:
-            raise AttributeError(key)
-
-    def clear(self):
-        dict.clear(self)
-        self._keys = []
-
-    def popitem(self):
-        if len(self._keys) == 0:
-            raise KeyError('dictionary is empty')
-        else:
-            key = self._keys[-1]
-            val = self[key]
-            del self[key]
-            return key, val
-
-    def setdefault(self, key, failobj = None):
-        if key not in self:
-            self._keys.append(key)
-        dict.setdefault(self, key, failobj)
-
-    def update(self, d):
-        for key in d.keys():
-            if not self.has_key(key):
-                self._keys.append(key)
-        dict.update(self, d)
-
-    def iterkeys(self):
-        return iter(self._keys)
-
-    def keys(self):
-        return self._keys[:]
-
-    def itervalues(self):
-        for k in self._keys:
-            yield self[k]
-
-    def values(self):
-        return list(self.itervalues())
-
-    def iteritems(self):
-        for k in self._keys:
-            yield k, self[k]
-
-    def items(self):
-        return list(self.iteritems())
-
-    def __iter__(self):
-        return self.iterkeys()
-
-    def index(self, key):
-        if not self.has_key(key):
-            raise KeyError(key)
-        return self._keys.index(key)
-
-class DefaultDict(dict):
-    """Dictionary with a default value for unknown keys.
-    Source: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/389639
-        >>> a = DefaultDict(0)
-        >>> a.foo
-        0
-        >>> a['bar']
-        0
-        >>> a.x = 1
-        >>> a.x
-        1
-    """
-    def __init__(self, default):
-        self.default = default
-
-    def __getitem__(self, key):
-        if key in self: 
-            return self.get(key)
-        else:
-            ## Need copy in case self.default is something like []
-            return self.setdefault(key, copy.deepcopy(self.default))
-
-    def __getattr__(self, key):
-        # special care special methods
-        if key.startswith('__'):
-            return dict.__getattr__(self, key)
-        else:
-            return self[key]
-
-    __setattr__ = dict.__setitem__
-
-    def __copy__(self):
-        copy = DefaultDict(self.default)
-        copy.update(self)
-        return copy
-
-storage = DefaultDict(OrderedDict())    
+storage = defaultdict(OrderedDict)
 
 class SiteLocalDict:
     """
     Takes a dictionary that maps sites to objects.
-    When somebody tries to get or set an attribute or item 
-    of the SiteLocalDict, it passes it on to the object 
+    When somebody tries to get or set an attribute or item
+    of the SiteLocalDict, it passes it on to the object
     for the active site in dictionary.
     Active site is found from `context.site`.
     see infogami.utils.context.context
-    """    
+    """
     def __init__(self):
         self.__dict__['_SiteLocalDict__d'] = {}
 
@@ -182,16 +55,16 @@ class ReadOnlyDict:
             raise AttributeError(key)
 
 class DictPile(DictMixin):
-    """Pile of ditionaries. 
+    """Pile of ditionaries.
     A key in top dictionary covers the key with the same name in the bottom dictionary.
 
         >>> a = {'x': 1, 'y': 2}
         >>> b = {'y': 5, 'z': 6}
         >>> d = DictPile([a, b])
-        >>> d['x'], d['y'], d['z'] 
+        >>> d['x'], d['y'], d['z']
         (1, 5, 6)
         >>> b['x'] = 4
-        >>> d['x'], d['y'], d['z'] 
+        >>> d['x'], d['y'], d['z']
         (4, 5, 6)
         >>> c = {'x':0, 'y':1}
         >>> d.add_dict(c)

--- a/infogami/utils/template.py
+++ b/infogami/utils/template.py
@@ -1,19 +1,21 @@
 """
 Template Management.
 
-In Infogami, templates are provided by multiple plugins. This module takes 
+In Infogami, templates are provided by multiple plugins. This module takes
 templates from each module and makes them available under single namespace.
 
-There could also be multiple sources of templates. For example, from plugins 
-and from the wiki. The `Render` class takes care of providing the correct 
+There could also be multiple sources of templates. For example, from plugins
+and from the wiki. The `Render` class takes care of providing the correct
 template from multiple template sources and error handling.
 """
-import web
 import os
 import time
-import storage
 
-# There are some backward-incompatible changes in web.py 0.34 which makes Infogami fail. 
+import web
+
+from infogami.utils import storage
+
+# There are some backward-incompatible changes in web.py 0.34 which makes Infogami fail.
 # Monkey-patching web.py to fix that issue.
 if web.__version__ == "0.34":
     from UserDict import DictMixin
@@ -100,7 +102,7 @@ def find(path):
 
 #@@ Find a better name
 class Render(storage.DictPile):
-    add_source = storage.DictPile.add_dict        
+    add_source = storage.DictPile.add_dict
 
     def __getitem__(self, key):
         # take templates from all sources
@@ -121,7 +123,7 @@ class Render(storage.DictPile):
 
 def usermode(f):
     """Returns a function that calls f after switching to user mode of tdb.
-    In user mode, saving of things will be disabled to protect user written 
+    In user mode, saving of things will be disabled to protect user written
     templates from modifying things.
     """
     def g(*a, **kw):
@@ -160,7 +162,7 @@ def saferender(templates, *a, **kw):
             import traceback
             traceback.print_exc()
 
-            import view            
+            import view
             message = str(t.filename) + ': error in processing template: ' + e.__class__.__name__ + ': ' + str(e) + ' (falling back to default template)'
             view.add_flash_message('error', message)
 
@@ -171,7 +173,7 @@ def typetemplate(name):
     def template(page, *a, **kw):
         default_template = getattr(render, 'default_' + name, None)
         key = page.type.key[1:] + '/' + name
-        t = getattr(render, web.utf8(key), default_template)
+        t = getattr(render, web.safestr(key), default_template)
         return t(page, *a, **kw)
     return template
 

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -69,7 +69,7 @@ web.template.Template.globals.update(dict(
   isinstance = isinstance,
   enumerate = enumerate,
   hasattr = hasattr,
-  utf8 = web.utf8,
+  utf8 = web.safestr,
   Dropdown = web.form.Dropdown,
   slice = slice,
   urlencode = urlencode,
@@ -97,7 +97,7 @@ def safeint(value, default=0):
 def safeadd(*items):
     s = ''
     for i in items:
-        s += (i and web.utf8(i)) or ''
+        s += (i and web.safestr(i)) or ''
     return s
 
 @public
@@ -114,8 +114,8 @@ def http_status(status):
 
 @public
 def join(sep, items):
-    items = [web.utf8(item or "") for item in items]
-    return web.utf8(sep).join(items)
+    items = [web.safestr(item or "") for item in items]
+    return web.safestr(sep).join(items)
 
 @public
 def format(text, safe_mode=False):


### PR DESCRIPTION
* Fix for https://github.com/internetarchive/openlibrary/pull/2416#issuecomment-535998852 where dependancy __web.py__ has remove __web.utf8()__ in favor of __web.safestr()__.
* Cherrypicks several noncontroversial changes from #45 so that PR can remain focused on the conversion from DictMixin --> Mapping.