### PR TITLE
Update i18n.py

### DIFF
--- a/infogami/utils/i18n.py
+++ b/infogami/utils/i18n.py
@@ -163,6 +163,17 @@ def dirstrip(f, dir):
     f = web.lstrips(f, dir)
     return web.lstrips(f, '/')
 
+def read_strings(path):
+    """Return a version of file's contents without __builtins__
+    (which gets added by execfile
+    """
+    env = {}
+    with open(path) as in_file:
+        exec(in_file.read(), env)
+    if '__builtins__' in env:
+        del env['__builtins__']
+    return env
+    
 def load_strings(plugin_path):
     """Load string.xx files from plugin/i18n/string.* files."""
     import os.path
@@ -173,15 +184,6 @@ def load_strings(plugin_path):
         namespace = os.path.dirname(path)
         _, extn = os.path.splitext(p)
         return '/' + namespace, extn[1:] # strip dot
-
-    def read_strings(path):
-        env = {}
-        with open(path) as in_file:
-            exec(in_file.read(), env)
-        # __builtins__ gets added by execfile
-        if '__builtins__' in env:
-            del env['__builtins__']
-        return env
 
     root = os.path.join(plugin_path, 'i18n')
     for p in find(root, r'strings\..*'):


### PR DESCRIPTION
Resolves `SyntaxError: unqualified exec is not allowed in function` for `i18n`
```
Traceback (most recent call last):
  File "/opt/openlibrary/venv/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/opt/openlibrary/venv/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/opt/openlibrary/venv/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/opt/openlibrary/venv/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/opt/openlibrary/openlibrary/scripts/openlibrary-server", line 82, in load
    load_infogami(self.config_file)
  File "/opt/openlibrary/openlibrary/scripts/openlibrary-server", line 52, in load_infogami
    from infogami.utils import delegate
  File "/opt/openlibrary/deploys/openlibrary/openlibrary/infogami/utils/delegate.py", line 6, in <module>
    from infogami.utils import features, i18n, macro, template
SyntaxError: unqualified exec is not allowed in function 'read_strings' it is a nested function (i18n.py, line 180)
```