### PR TITLE
Fixes python3 problem with conftest

### DIFF
--- a/infogami/infobase/tests/conftest.py
+++ b/infogami/infobase/tests/conftest.py
@@ -1,1 +1,0 @@
-from infogami.infobase.tests.pytest_wildcard import wildcard

--- a/infogami/infobase/tests/conftest.py
+++ b/infogami/infobase/tests/conftest.py
@@ -1,1 +1,1 @@
-from infogami.infobase.tests.pytest_wildcard import *
+from infogami.infobase.tests.pytest_wildcard import wildcard

--- a/infogami/infobase/tests/test_client.py
+++ b/infogami/infobase/tests/test_client.py
@@ -2,7 +2,7 @@ import simplejson
 
 from infogami.infobase import client, server
 from infogami.infobase.tests import utils
-
+from infogami.infobase.tests.pytest_wildcard import wildcard
 
 def setup_module(mod):
     utils.setup_conn(mod)

--- a/infogami/infobase/tests/test_read.py
+++ b/infogami/infobase/tests/test_read.py
@@ -5,6 +5,7 @@ from infogami.infobase._dbstore.save import SaveImpl
 from infogami.infobase._dbstore.store import Store
 from infogami.infobase._dbstore.read import RecentChanges
 from infogami.infobase.tests import utils
+from infogami.infobase.tests.pytest_wildcard import wildcard
 
 
 def setup_module(mod):

--- a/infogami/infobase/tests/test_save.py
+++ b/infogami/infobase/tests/test_save.py
@@ -6,6 +6,7 @@ import web
 
 from infogami.infobase._dbstore.save import SaveImpl, IndexUtil, PropertyManager
 from infogami.infobase.tests import utils
+from infogami.infobase.tests.pytest_wildcard import wildcard
 
 
 def setup_module(mod):

--- a/infogami/infobase/tests/test_store.py
+++ b/infogami/infobase/tests/test_store.py
@@ -1,17 +1,21 @@
-import py.test
+import pytest
 import simplejson
 
 from infogami.infobase import common
-from infogami.infobase.tests import utils
 from infogami.infobase._dbstore.store import Store, TypewiseIndexer
+from infogami.infobase.tests import utils
+from infogami.infobase.tests.pytest_wildcard import wildcard
+
 
 def setup_module(mod):
     utils.setup_db(mod)
     mod.store = Store(db)
 
+
 def teardown_module(mod):
     utils.teardown_db(mod)
     mod.store = None
+
 
 class DBTest:
     def setup_method(self, method):
@@ -20,6 +24,7 @@ class DBTest:
 
     def teardown_method(self, method):
         self.tx.rollback()
+
 
 class TestStore(DBTest):
     global store
@@ -44,7 +49,7 @@ class TestStore(DBTest):
         foo = store.put("foo", {"name": "foo"})
 
         # calling without _rev should fail
-        assert py.test.raises(common.Conflict, store.put, "foo", {"name": "bar"})
+        assert pytest.raises(common.Conflict, store.put, "foo", {"name": "bar"})
 
         # Calling with _rev should update foo
         foo2 = store.put("foo", {"name": "foo2", "_rev": foo['_rev']})
@@ -55,7 +60,7 @@ class TestStore(DBTest):
         foo3 = store.put("foo", {"name": "foo3", "_rev": None})
 
         # calling with bad/stale _rev should fail
-        assert py.test.raises(common.Conflict, store.put, "foo", {"name": "foo4", "_rev": foo['_rev']})
+        assert pytest.raises(common.Conflict, store.put, "foo", {"name": "foo4", "_rev": foo['_rev']})
 
     def test_notfound(self):
         assert store.get("xxx") is None


### PR DESCRIPTION
Example CI error:
https://travis-ci.org/internetarchive/infogami/jobs/608002780?utm_medium=notification&utm_source=github_status

```
________________________ ERROR collecting test session _________________________
../../../virtualenv/python3.8.0/lib/python3.8/site-packages/_pytest/config/__init__.py:456: in _importconftest
    return self._conftestpath2mod[key]
E   KeyError: PosixPath('/home/travis/build/internetarchive/infogami/infogami/infobase/tests/conftest.py')
```

Fixed by deleting the `infogami/infobase/tests/conftest.py` file which only had a single wildcard import for `wildcard`, and adding the explicit import into the test files that use it.