### PR TITLE
Fix markdown import errors under python3

### DIFF
--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -24,7 +24,6 @@ FN_BACKLINK_TEXT = "zz1337820767766393qq"
 import random
 import re
 
-
 from infogami.utils.markdown import markdown
 
 

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -23,6 +23,7 @@ FN_BACKLINK_TEXT = "zz1337820767766393qq"
 
 import re, markdown, random
 
+
 class FootnoteExtension (markdown.Extension):
 
     DEF_RE = re.compile(r'(\ ?\ ?\ ?)\[\^([^\]]*)\]:\s*(.*)')
@@ -210,7 +211,7 @@ class FootnotePreprocessor :
         return counter, None, None
 
 
-class FootnotePattern (markdown.Pattern) :
+class FootnotePattern (markdown.inlinepatterns.Pattern) :
 
     def __init__ (self, pattern, footnotes) :
 
@@ -228,6 +229,7 @@ class FootnotePattern (markdown.Pattern) :
         a.appendChild(doc.createTextNode(str(num)))
         return sup
 
+
 class FootnotePostprocessor (markdown.Postprocessor):
 
     def __init__ (self, footnotes) :
@@ -242,6 +244,7 @@ class FootnotePostprocessor (markdown.Postprocessor):
             else :
                 doc.documentElement.appendChild(footnotesDiv)
 
+
 class FootnoteTextPostprocessor (markdown.Postprocessor):
 
     def __init__ (self, footnotes) :
@@ -250,6 +253,6 @@ class FootnoteTextPostprocessor (markdown.Postprocessor):
     def run(self, text) :
         return text.replace(FN_BACKLINK_TEXT, "&#8617;")
 
+
 def makeExtension(configs=None) :
     return FootnoteExtension(configs=configs)
-

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -23,6 +23,15 @@ FN_BACKLINK_TEXT = "zz1337820767766393qq"
 
 import re, markdown, random
 
+try:
+    from markdown import Pattern
+except ImportError:
+    from markdown.inlinepatterns import Pattern
+
+try:
+    from markdown import Postprocessor
+except ImportError:
+    from markdown.postprocessors import Postprocessor
 
 class FootnoteExtension (markdown.Extension):
 
@@ -211,11 +220,11 @@ class FootnotePreprocessor :
         return counter, None, None
 
 
-class FootnotePattern (markdown.inlinepatterns.Pattern) :
+class FootnotePattern (Pattern) :
 
     def __init__ (self, pattern, footnotes) :
 
-        markdown.Pattern.__init__(self, pattern)
+        Pattern.__init__(self, pattern)
         self.footnotes = footnotes
 
     def handleMatch(self, m, doc) :
@@ -230,7 +239,7 @@ class FootnotePattern (markdown.inlinepatterns.Pattern) :
         return sup
 
 
-class FootnotePostprocessor (markdown.Postprocessor):
+class FootnotePostprocessor (Postprocessor):
 
     def __init__ (self, footnotes) :
         self.footnotes = footnotes
@@ -245,7 +254,7 @@ class FootnotePostprocessor (markdown.Postprocessor):
                 doc.documentElement.appendChild(footnotesDiv)
 
 
-class FootnoteTextPostprocessor (markdown.Postprocessor):
+class FootnoteTextPostprocessor (Postprocessor):
 
     def __init__ (self, footnotes) :
         self.footnotes = footnotes

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -21,7 +21,8 @@ method.
 FN_BACKLINK_TEXT = "zz1337820767766393qq"
 
 
-import re, random
+import random
+import re
 
 
 from infogami.utils.markdown import markdown

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -21,17 +21,11 @@ method.
 FN_BACKLINK_TEXT = "zz1337820767766393qq"
 
 
-import re, markdown, random
+import re, random
 
-try:
-    from markdown import Pattern
-except ImportError:
-    from markdown.inlinepatterns import Pattern
 
-try:
-    from markdown import Postprocessor
-except ImportError:
-    from markdown.postprocessors import Postprocessor
+from infogami.utils import markdown
+
 
 class FootnoteExtension (markdown.Extension):
 
@@ -220,11 +214,11 @@ class FootnotePreprocessor :
         return counter, None, None
 
 
-class FootnotePattern (Pattern) :
+class FootnotePattern (markdown.Pattern) :
 
     def __init__ (self, pattern, footnotes) :
 
-        Pattern.__init__(self, pattern)
+        markdown.Pattern.__init__(self, pattern)
         self.footnotes = footnotes
 
     def handleMatch(self, m, doc) :
@@ -239,7 +233,7 @@ class FootnotePattern (Pattern) :
         return sup
 
 
-class FootnotePostprocessor (Postprocessor):
+class FootnotePostprocessor (markdown.Postprocessor):
 
     def __init__ (self, footnotes) :
         self.footnotes = footnotes
@@ -254,7 +248,7 @@ class FootnotePostprocessor (Postprocessor):
                 doc.documentElement.appendChild(footnotesDiv)
 
 
-class FootnoteTextPostprocessor (Postprocessor):
+class FootnoteTextPostprocessor (markdown.Postprocessor):
 
     def __init__ (self, footnotes) :
         self.footnotes = footnotes

--- a/infogami/utils/markdown/mdx_footnotes.py
+++ b/infogami/utils/markdown/mdx_footnotes.py
@@ -24,7 +24,7 @@ FN_BACKLINK_TEXT = "zz1337820767766393qq"
 import re, random
 
 
-from infogami.utils import markdown
+from infogami.utils.markdown import markdown
 
 
 class FootnoteExtension (markdown.Extension):


### PR DESCRIPTION
Scope of this change has reduced thanks to #55 , but this changes the `markdown` import from the external module (which gave errors under python3) to the _local_ module, which it was originally. I think this is the safer way to go for now. @cclauss , please confirm I have this the correct way round :)
