### PR TITLE
from __future__ import absolute_import in infogami/utils/app.py

### DIFF
--- a/infogami/utils/app.py
+++ b/infogami/utils/app.py
@@ -1,5 +1,7 @@
 """Infogami application.
 """
+from __future__ import absolute_import
+
 import collections
 import os
 import re
@@ -13,8 +15,6 @@ import six
 
 urls = ("/.*", "item")
 app = web.application(urls, globals(), autoreload=False)
-
-import delegate as infogami_delegate  # create app before importing delegate
 
 # magical metaclasses for registering special paths and modes.
 # Whenever any class extends from page/mode, an entry is added to pages/modes.
@@ -80,8 +80,9 @@ class view(six.with_metaclass(metaview)):
     types = None
 
     def emit_json(self, data):
+        from infogami.utils.delegate import RawText
         web.header('Content-Type', 'application/json')
-        return infogami_delegate.RawText(simplejson.dumps(data))
+        return RawText(simplejson.dumps(data))
 
     def delegate(self, page):
         converters = {"json" : self.emit_json}


### PR DESCRIPTION
These changes break a circular import.

Just adding `from __future__ import absolute_import` to `infogami/utils/app.py` broke our Travis CI tests for Python 2. These modifications enable us to continue to pass the Python 2 tests and enable us to start executing the Python 3 tests.   @hornc