### PR TITLE
Travis CI: codespell dedup() --> dedupe()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 group: travis_latest
 os: linux
-dist: focal
+dist: xenial  # focal
 language: python
 env:
   - UPGRADE_WEBPY=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database infobase_test;' -U postgres
-  - codespell . --ignore-words-list=ba,dedup,referer --quiet-level=2
+  - codespell . --ignore-words-list=ba,referer --quiet-level=2
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F401,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 group: travis_latest
+os: linux
+dist: focal
 language: python
 env:
   - UPGRADE_WEBPY=false
@@ -6,7 +8,7 @@ env:
 python:
   - 2.7
   - 3.8
-matrix:
+jobs:
   allow_failures:
     - python: 3.8
 install:
@@ -17,7 +19,7 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database infobase_test;' -U postgres
-  - codespell . --ignore-words-list=ba,referer --quiet-level=2
+  - codespell . --ignore-words-list=ba,dedup,referer --quiet-level=2
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F401,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -123,7 +123,7 @@ class SaveImpl:
     def _update_index(self, records):
         self.indexUtil.update_index(records)
 
-    def dedup(self, docs):
+    def dedupe(self, docs):
         x = set()
         docs2 = []
         for doc in docs[::-1]:
@@ -135,7 +135,7 @@ class SaveImpl:
         return docs2[::-1]
 
     def _get_records_for_save(self, docs, timestamp):
-        docs = self.dedup(docs)
+        docs = self.dedupe(docs)
         keys = [doc['key'] for doc in docs]
         type_ids = self.get_thing_ids(doc['type']['key'] for doc in docs)
 


### PR DESCRIPTION
This should get our Travis CI tests on legacy Python tests green again...