### PR TITLE
A fix for work.get_sorted_edition() on Python 3

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -714,7 +714,7 @@ def create_thing(site, key, data, revision=None):
     klass = _thing_class_registry.get(type) or _thing_class_registry.get(None)
     return klass(site, key, data, revision)
 
-class Thing(object):
+class Thing:
     def __init__(self, site, key, data=None, revision=None):
         self._site = site
         self.key = key
@@ -844,17 +844,14 @@ class Thing(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    #def __str__(self):
-    #    return web.safestr(self.key)
+    def __str__(self):
+        return web.safestr(self.key)
 
     def __repr__(self):
-    #    if self.key:
-    #        return "<Thing: %s>" % repr(self.key)
-    #    else:
-    #        return "<Thing: %s>" % repr(self._data)
-        return "{}(site={}, key={}, data={}, revision={})".format(
-            self.__class__.__name__, self._site, self.key, self._data, self._revision
-        )
+        if self.key:
+            return "<Thing: %s>" % repr(self.key)
+        else:
+            return "<Thing: %s>" % repr(self._data)
 
 class Type(Thing):
     def _get_defaults(self):

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -714,7 +714,7 @@ def create_thing(site, key, data, revision=None):
     klass = _thing_class_registry.get(type) or _thing_class_registry.get(None)
     return klass(site, key, data, revision)
 
-class Thing:
+class Thing(object):
     def __init__(self, site, key, data=None, revision=None):
         self._site = site
         self.key = key
@@ -844,14 +844,17 @@ class Thing:
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def __str__(self):
-        return web.safestr(self.key)
+    #def __str__(self):
+    #    return web.safestr(self.key)
 
     def __repr__(self):
-        if self.key:
-            return "<Thing: %s>" % repr(self.key)
-        else:
-            return "<Thing: %s>" % repr(self._data)
+    #    if self.key:
+    #        return "<Thing: %s>" % repr(self.key)
+    #    else:
+    #        return "<Thing: %s>" % repr(self._data)
+        return "{}(site={}, key={}, data={}, revision={})".format(
+            self.__class__.__name__, self._site, self.key, self._data, self._revision
+        )
 
 class Type(Thing):
     def _get_defaults(self):

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -246,7 +246,8 @@ def thingview(page):
     and page.works[0] is not a Work object then create a new Work from its data
     """
     if not page.key.startswith('/works'):  # debug: internetarchive/openlibrary#3633
-        work = page.works[0]
+        page_works = list(page.works)
+        work = page_works[0]  # TypeError: LazyObject object is not subscriptable
         from openlibrary.plugins.upstream.models import Work
         # If the key says that it is a work but it is a Thing object, not a Work object
         if work.key.startswith('/works') and not isinstance(work, Work):

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -240,6 +240,16 @@ def thingdiff(type, name, v1, v2):
 
 @public
 def thingview(page):
+    if not page.key.startswith('/works'):  # debug: internetarchive/openlibrary#3633
+        work = page.works[0]
+        if isinstance(work.get_sorted_editions, client.Nothing):
+            from openlibrary.plugins.upstream.models import Work
+            page.works[0] = Work(
+                site=work._site, key=work.key, data=web.Storage(), revision=work._revision
+            )
+            # work.data = web.Storage()
+            # work._data = web.Storage()
+            assert not isinstance(page.works[0].get_sorted_editions, client.Nothing)
     return render.view(page)
 
 @public

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -37,11 +37,6 @@ def get_markdown(text, safe_mode=False):
 def get_doc(text):
     return get_markdown(text)._transform()
 
-try:
-    breakpoint  # Python >= 3.7
-except NameError:
-    from ptvsd import break_into_debugger as breakpoint
-
 web.template.Template.globals.update(dict(
   changequery = web.changequery,
   url = web.url,
@@ -77,7 +72,6 @@ web.template.Template.globals.update(dict(
   slice = slice,
   urlencode = urlencode,
   debug = web.debug,
-  breakpoint = breakpoint,
   add_flash_message = add_flash_message,
   get_flash_messages = get_flash_messages,
   render_template = render_template,

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -240,11 +240,16 @@ def thingdiff(type, name, v1, v2):
 
 @public
 def thingview(page):
+    """
+    Fix for internetarchive/openlibrary#3633
+    If the page does not start with /works but page.works[0] starts with /works
+    and page.works[0] is not a Work object then create a new Work from its data
+    """
     if not page.key.startswith('/works'):  # debug: internetarchive/openlibrary#3633
         work = page.works[0]
-        assert work.key.startswith('/works')  # The key says that it is a work
         from openlibrary.plugins.upstream.models import Work
-        if not isinstance(work, Work):  # But work is a Thing, not a Work object
+        # If the key says that it is a work but it is a Thing object, not a Work object
+        if work.key.startswith('/works') and not isinstance(work, Work):
             page.works[0] = Work(  # Give it a .get_sorted_editions() method
                 site=work._site, key=work.key, data=work._data, revision=work._revision
             )

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -242,16 +242,14 @@ def thingdiff(type, name, v1, v2):
 def thingview(page):
     """
     Fix for internetarchive/openlibrary#3633
-    If the page does not start with /works but page.works[0] starts with /works
-    and page.works[0] is not a Work object then create a new Work from its data
+    If the page does not start with /works/ but page.works[0] starts with /works/ but
+    there is no page.works[0].get_sorted_editions() then get the work from web.ctx.site
     """
-    if not page.key.startswith('/works'):  # debug: internetarchive/openlibrary#3633
-        page_works = list(page.works)  # Force the loading of the LazyObject object
-        if page_works:
-            work = page_works[0]
-            # If the key says that it is a work but it has no .get_sorted_editions()
-            if work.key.startswith('/works/') and str(work.get_sorted_editions) == "":
-                page.works[0] = web.ctx.site.get(work.key)  # Add get_sorted_editions()
+    if not page.key.startswith('/works/'):  # debug: internetarchive/openlibrary#3633
+        work = page.works and list(page.works)[0]  # Force loading of LazyObject object
+        # If the key says that it is a work but it has no .get_sorted_editions()
+        if work and work.key.startswith('/works/') and not str(work.get_sorted_editions):
+            page.works[0] = web.ctx.site.get(work.key)  # Add .get_sorted_editions()
     return render.view(page)
 
 @public

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -249,13 +249,9 @@ def thingview(page):
         page_works = list(page.works)  # Force the loading of the LazyObject object
         if page_works:
             work = page_works[0]
-            from openlibrary.plugins.upstream.models import Work
-            # If the key says that it is a work but it is a Thing, not a Work object
-            if work.key.startswith('/works') and not isinstance(work, Work):
-                page.works[0] = Work(  # Give it a .get_sorted_editions() method
-                    site=work._site, key=work.key, data=work._data,
-                    revision=work._revision
-                )
+            # If the key says that it is a work but it has no .get_sorted_editions()
+            if work.key.startswith('/works/') and str(work.get_sorted_editions) == "":
+                page.works[0] = web.ctx.site.get(work.key)  # Add get_sorted_editions()
     return render.view(page)
 
 @public

--- a/infogami/utils/view.py
+++ b/infogami/utils/view.py
@@ -246,14 +246,16 @@ def thingview(page):
     and page.works[0] is not a Work object then create a new Work from its data
     """
     if not page.key.startswith('/works'):  # debug: internetarchive/openlibrary#3633
-        page_works = list(page.works)
-        work = page_works[0]  # TypeError: LazyObject object is not subscriptable
-        from openlibrary.plugins.upstream.models import Work
-        # If the key says that it is a work but it is a Thing object, not a Work object
-        if work.key.startswith('/works') and not isinstance(work, Work):
-            page.works[0] = Work(  # Give it a .get_sorted_editions() method
-                site=work._site, key=work.key, data=work._data, revision=work._revision
-            )
+        page_works = list(page.works)  # Force the loading of the LazyObject object
+        if page_works:
+            work = page_works[0]
+            from openlibrary.plugins.upstream.models import Work
+            # If the key says that it is a work but it is a Thing, not a Work object
+            if work.key.startswith('/works') and not isinstance(work, Work):
+                page.works[0] = Work(  # Give it a .get_sorted_editions() method
+                    site=work._site, key=work.key, data=work._data,
+                    revision=work._revision
+                )
     return render.view(page)
 
 @public


### PR DESCRIPTION
Fixes internetarchive/openlibrary#3633 as can be seen at http://staging.openlibrary.org/books/OL42679M

Fixes internetarchive/openlibrary#3688

It is unclear why this solution is required on Python 3 but not on Python 2 but it fixes internetarchive/openlibrary#3633.  @aasifkhan7 @mekarpeles @cdrini 

Update: The problem here is that the key of `page.works[0]` starts with `/works` but the object is a [`infogami.infobase.client.Thing`](https://github.com/internetarchive/infogami/blob/master/infogami/infobase/client.py#L717) and not a [`openlibrary.plugins.upstream.models.Work`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/models.py#L528) and therefore does not have access to the [`Works.get_sorted_edition()`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/models.py#L665) method.

The proposed solution is to convert the Thing object into a Work object so it has access to that method.

The data and classes are identical in both Py2 and Py3 so I still have no idea why this fix is only _required_ on Python 3.  But this fix does work smoothly on both Py2 and Py3.