### PR TITLE
Make repr(Thing) useful for debugging

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -848,10 +848,9 @@ class Thing:
         return web.safestr(self.key)
 
     def __repr__(self):
-        if self.key:
-            return "<Thing: %s>" % repr(self.key)
-        else:
-            return "<Thing: %s>" % repr(self._data)
+        return "{}(site={}, key={}, data={}, revision={})".format(
+            self.__class__.__name__, self._site, self.key, self._data, self._revision
+        )
 
 class Type(Thing):
     def _get_defaults(self):


### PR DESCRIPTION
Currently, repr() of a Thing object provides no detail about the content of that thing which makes debugging difficult.

This pull request advocates that `Thing.__repr__()` is a valid Python expression that could be used to recreate an object with the same value as suggested at [`https://docs.python.org/3/reference/datamodel.html#object.__repr__`](https://docs.python.org/3/reference/datamodel.html#object.__repr__)