### PR TITLE
Fix Thing.setattr()

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -780,7 +780,9 @@ class Thing:
         self._getdata()[key] = value
 
     def __setattr__(self, key, value):
-        if key in ['key', 'revision', 'latest_revision', 'last_modified', 'created'] or key.startswith('_'):
+        if key == '__class__':
+            object.__setattr__(self, '__class__', value)
+        elif key in ['key', 'revision', 'latest_revision', 'last_modified', 'created'] or key.startswith('_'):
             self.__dict__[key] = value
         else:
             self._getdata()[key] = value


### PR DESCRIPTION
Fixes internetarchive/openlibrary#3633, internetarchive/openlibrary#3670, internetarchive/openlibrary#3688

This is a simple workaround for the fact that [`self.__class__ = _thing_class_registry.get(self._data.get('type').key, Thing)`](https://github.com/internetarchive/infogami/blob/master/infogami/infobase/client.py#L747) works sporatically on new-style classes and therefor on Python 3.  This PR advocates using the parent's (object) .setaddr() method instead of directly setting `.__class__`.