### PR TITLE
Travis CI: Job “Python 3.8 - Test OL on Infogami” is now mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ jobs:
       env: UPGRADE_WEBPY=true
   allow_failures:
     - script: bash scripts/pytests_failing_on_py2_and_py3.sh
-    - name: "Python: 3.8 - Test Open Library"
 install:
   - pip install codespell flake8 pytest psycopg2
   - pip install -r requirements.txt


### PR DESCRIPTION
👍 ❤️ 🎉 🚀 It is now mandatory that Python 3 Infogami plus Open Library pass all pytests and doctests for the build to pass.