### PR TITLE
Py3: Fix dictionary changed size during iteration again

### DIFF
--- a/infogami/core/code.py
+++ b/infogami/core/code.py
@@ -92,7 +92,7 @@ class edit (delegate.mode):
         i = web.storage(helpers.unflatten(i))
         i.key = path
 
-        _ = web.storage((k, i.pop(k)) for k in i.keys() if k.startswith('_'))
+        _ = web.storage((k, i.pop(k)) for k in list(i.keys()) if k.startswith('_'))
         action = self.get_action(_)
         comment = _.get('_comment', None)
 


### PR DESCRIPTION
Similar fix to #108... Python 3 has zero-tolerance for dicts that grow or shrink during iteration.
This PR proposes to fix that by freezing the `i.keys()` in a `list()`.