### PR TITLE
str' object has no attribute 'decode'

### DIFF
--- a/infogami/utils/macro.py
+++ b/infogami/utils/macro.py
@@ -59,7 +59,7 @@ def call_macro(name, args):
             result = "%s failed with error: <pre>%s</pre>" % (name, web.websafe(str(e)))
             import traceback
             traceback.print_exc()
-        return str(result).decode('utf-8')
+        return str(result)
     else:
         return "Unknown macro: <pre>%s</pre>" % name
 


### PR DESCRIPTION
In Python 3 `bytes.decode()` and `str.encode()` are opposite operations and are used to perform reliable conversions. However, `bytes.encode()` and `str.decode()` do not exist!  Given that we already have a `str` let's just return it unmodified.

![Screenshot 2020-10-30 at 17 09 42](https://user-images.githubusercontent.com/3709715/97729680-3be1af80-1ad3-11eb-8cb3-82f34f49ea86.png)