### PR TITLE
if not site: raise RuntimeError

### DIFF
--- a/infogami/infobase/server.py
+++ b/infogami/infobase/server.py
@@ -382,6 +382,8 @@ class account:
     @jsonify
     def delegate(self, sitename, method):
         site = get_site(sitename)
+        if not site:
+            raise RuntimeError("get_site({}) failed".format(sitename))
         methodname = "%s_%s" % (self.get_method(), method)
 
         m = getattr(self, methodname, None)


### PR DESCRIPTION
When calling `account.delegate()`, raise an exception when `get_site(sitename)` fails.