### PR TITLE
Use empty str instead of None in HTTP headers

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -152,7 +152,7 @@ class RemoteConnection(Connection):
             headers['Cookie'] = cookie
 
         # pass the remote ip to the infobase server
-        headers['X-REMOTE-IP'] = web.ctx.get('ip')
+        headers['X-REMOTE-IP'] = web.ctx.get('ip') or ''
 
         try:
             conn.request(method, path, data, headers=headers)


### PR DESCRIPTION
Closes internetarchive/openlibrary#4497

As discussed in internetarchive/olsystem#110 the cron jobs for `store_counts.py` and `expire_accounts.py` fail on Python 3 because we are passing in `None` as an HTTP header value instead of the empty string.
```
2021-01-28 19:09:25 [333] [openlibrary.admin.stats] [INFO]   admin_delta__subjects - 0
Traceback (most recent call last):
  File "/openlibrary/scripts/store_counts.py", line 15, in <module>
    sys.exit(stats.main(*sys.argv[1:]))
  File "/openlibrary/openlibrary/admin/stats.py", line 136, in main
    store_data(data, today.strftime("%Y-%m-%d"))
  File "/openlibrary/openlibrary/admin/stats.py", line 60, in store_data
    web.ctx.site.store[uid] = doc
  File "/openlibrary/infogami/infobase/client.py", line 574, in __setitem__
    return self._request(key, method='PUT', data=simplejson.dumps(data))
  File "/openlibrary/infogami/infobase/client.py", line 526, in _request
    out = self.conn.request(self.name, "/_store/" + path, method, data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 53, in request
    return self.store_put(sitename, path, data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 100, in store_put
    return self.conn.request(sitename, path, 'PUT', data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 53, in request
    return self.store_put(sitename, path, data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 100, in store_put
    return self.conn.request(sitename, path, 'PUT', data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 53, in request
    return self.store_put(sitename, path, data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 383, in store_put
    result = ConnectionMiddleware.store_put(self, sitename, path, data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 100, in store_put
    return self.conn.request(sitename, path, 'PUT', data)
  File "/openlibrary/openlibrary/plugins/openlibrary/connection.py", line 542, in request
    return self.writer.request(sitename, path, method, data=data)
  File "/openlibrary/infogami/infobase/client.py", line 158, in request
    conn.request(method, path, data, headers=headers)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/http/client.py", line 1255, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/http/client.py", line 1296, in _send_request
    self.putheader(hdr, value)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/http/client.py", line 1232, in putheader
    if _is_illegal_header_value(values[i]):
TypeError: expected string or bytes-like object
```