### PR TITLE
Remove unhelpful title

### DIFF
--- a/infogami/core/macros/RecentChanges.html
+++ b/infogami/core/macros/RecentChanges.html
@@ -23,7 +23,7 @@ $for v in changes:
     <td>$datestr(v.created)</td>
     <td><a href="$homepath()$v.key">$v.key</a></td>
     $if v.author:
-        <td><a href="$homepath()$v.author.key" title="$v.author.displayname">$v.author.displayname</a></div></td>
+        <td><a href="$homepath()$v.author.key">$v.author.displayname</a></div></td>
     $else:
         <td>$v.ip</td>    
     <td>$v.comment</td>


### PR DESCRIPTION
While reviewing [this PR](https://github.com/internetarchive/openlibrary/pull/4614), I found an instance of an anchor tag's `title` attribute matching its text.  This PR removes that unhelpful `title`.