### PR TITLE
PEP8: Avoid wildcard imports

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,7 +24,10 @@ jobs:
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt
-      - run: mypy --ignore-missing-imports . || true
+      - run:  mypy
+          --exclude infogami/infobase/bulkupload.py
+          --exclude migration/migrate-0.4-0.5.py
+          --ignore-missing-imports . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: psql -c 'create database infobase_test;' -U postgres || true
       - run: pytest . || true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check . || true
       - run: codespell . --ignore-words-list=ba,referer --quiet-level=2
-      - run: flake8 . --count --select=E9,F401,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --select=C,E5,E9,F4,F6,F7,F82 --max-complexity=43 --max-line-length=233 --show-source --statistics
       # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - run: isort --check-only --profile black . || true

--- a/infogami/core/forms.py
+++ b/infogami/core/forms.py
@@ -1,4 +1,5 @@
-from web.form import *
+from web.form import (Button, Checkbox, Form, Hidden, Password, Textbox,
+                      Validator, net, notnull, regexp)
 
 from infogami.core import db
 from infogami.utils import i18n

--- a/infogami/core/forms.py
+++ b/infogami/core/forms.py
@@ -1,5 +1,7 @@
 from web.form import (Button, Checkbox, Form, Hidden, Password, Textbox,
                       Validator, net, notnull, regexp)
+from web.form import *  # TODO (cclauss): Remove wildcard imports
+
 
 from infogami.core import db
 from infogami.utils import i18n

--- a/infogami/core/forms.py
+++ b/infogami/core/forms.py
@@ -1,6 +1,6 @@
 from web.form import (Button, Checkbox, Form, Hidden, Password, Textbox,
                       Validator, net, notnull, regexp)
-from web.form import *  # TODO (cclauss): Remove wildcard imports
+from web.form import *  # noqa: F403 TODO (cclauss): Remove wildcard imports
 
 
 from infogami.core import db

--- a/infogami/core/forms.py
+++ b/infogami/core/forms.py
@@ -1,6 +1,6 @@
 from web.form import (Button, Checkbox, Form, Hidden, Password, Textbox,
                       Validator, net, notnull, regexp)
-from web.form import *  # noqa: F403 TODO (cclauss): Remove wildcard imports
+from web.form import *  # noqa: F40 TODO (cclauss): Remove wildcard imports
 
 
 from infogami.core import db

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -6,10 +6,9 @@ import web
 from infogami import config
 from infogami.utils import features, i18n
 from infogami.utils.app import app, mode, page  # noqa: F401
-
+from infogami.utils.app import *  # TODO (cclauss): Remove wildcard imports
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
-from infogami.utils.view import *
 
 
 def create_site():

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -6,7 +6,7 @@ import web
 from infogami import config
 from infogami.utils import features, i18n
 from infogami.utils.app import app, mode, page  # noqa: F401
-from infogami.utils.app import *  # noqa: F403 TODO (cclauss): Remove wildcard imports
+from infogami.utils.app import *  # noqa: F40 TODO (cclauss): Remove wildcard imports
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
 

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -5,7 +5,7 @@ import web
 
 from infogami import config
 from infogami.utils import features, i18n
-from infogami.utils.app import *
+from infogami.utils.app import app
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
 

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -6,8 +6,11 @@ import web
 from infogami import config
 from infogami.utils import features, i18n
 from infogami.utils.app import app, mode, page  # noqa: F401
+
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
+from infogami.utils.view import *
+
 
 def create_site():
     from infogami.infobase import client

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -5,7 +5,7 @@ import web
 
 from infogami import config
 from infogami.utils import features, i18n
-from infogami.utils.app import app
+from infogami.utils.app import app, mode  # noqa: F401
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
 
@@ -13,7 +13,7 @@ def create_site():
     from infogami.infobase import client
 
     if config.site is None:
-        site = web.ctx.host.split(':')[0] # strip port
+        site = web.ctx.host.split(':')[0]  # strip port
     else:
         site = config.site
 

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -5,7 +5,7 @@ import web
 
 from infogami import config
 from infogami.utils import features, i18n
-from infogami.utils.app import app, mode  # noqa: F401
+from infogami.utils.app import app, mode, page  # noqa: F401
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
 

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -6,7 +6,7 @@ import web
 from infogami import config
 from infogami.utils import features, i18n
 from infogami.utils.app import app, mode, page  # noqa: F401
-from infogami.utils.app import *  # TODO (cclauss): Remove wildcard imports
+from infogami.utils.app import *  # noqa: F403 TODO (cclauss): Remove wildcard imports
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
 

--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -531,7 +531,7 @@ class HtmlBlockPreprocessor (Preprocessor):
                     left_tag = self._get_left_tag(block)
                     right_tag = self._get_right_tag(left_tag, block)
 
-                    if not (is_block_level(left_tag) \
+                    if not (is_block_level(left_tag)
                         or block[1] in ["!", "?", "@", "%"]):
                         new_blocks.append(block)
                         continue

--- a/infogami/utils/storage.py
+++ b/infogami/utils/storage.py
@@ -11,7 +11,7 @@ except ImportError:
 import web
 
 
-storage = defaultdict(OrderedDict)
+storage = defaultdict(OrderedDict)  # type: ignore
 
 
 class SiteLocalDict:


### PR DESCRIPTION
> Wildcard imports (from <module> import *) should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools.

https://www.python.org/dev/peps/pep-0008/#imports

mypy --exclude infogami/infobase/bulkupload.py --exclude migration/migrate-0.4-0.5.py --ignore-missing-imports .