### PR TITLE
repr(Nothing()) —> "<Nothing>", not empty str

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -642,11 +642,11 @@ class Nothing:
 
     >>> n = Nothing()
     >>> str(n)
-    'Nothing()'
+    '<Nothing>'
     >>> web.safestr(n)
-    'Nothing()'
+    '<Nothing>'
     >>> str([n])  # See #148 and #151
-    '[Nothing()]'
+    '[<Nothing>]'
     """
     def __getattr__(self, name):
         if name.startswith('__') or name == 'next':
@@ -685,7 +685,7 @@ class Nothing:
         return not (self == other)
 
     def __repr__(self):
-        return "Nothing()"
+        return "<Nothing>"
 
 nothing = Nothing()
 

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -642,9 +642,11 @@ class Nothing:
 
     >>> n = Nothing()
     >>> str(n)
-    ''
+    'Nothing()'
     >>> web.safestr(n)
-    ''
+    'Nothing()'
+    >>> bool([n])
+    True
     """
     def __getattr__(self, name):
         if name.startswith('__') or name == 'next':
@@ -682,8 +684,8 @@ class Nothing:
     def __ne__(self, other):
         return not (self == other)
 
-    def __str__(self): return ""
-    def __repr__(self): return ""
+    def __repr__(self):
+        return "Nothing()"
 
 nothing = Nothing()
 

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -645,8 +645,8 @@ class Nothing:
     'Nothing()'
     >>> web.safestr(n)
     'Nothing()'
-    >>> bool([n])
-    True
+    >>> str([n])  # See #148 and #151
+    '[Nothing()]'
     """
     def __getattr__(self, name):
         if name.startswith('__') or name == 'next':


### PR DESCRIPTION
Fixes #148,#152

[`https://docs.python.org/3/reference/datamodel.html#object.__repr__`](https://docs.python.org/3/reference/datamodel.html#object.__repr__)

`repr(Nothing())` is currently "" (empty str) and this PR would make it "Nothing()"
`str(Nothing())` is currently "" (empty str) and this PR would make it "Nothing()"
This should help eliminate the confusing situation where `bool([None]) is True` but `bool([Nothing()]) is False`