### PR TITLE
GitHub Action: Add a postgres service for testing

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: pip install black codespell flake8 isort mypy pytest pyupgrade
       - run: black --check . || true
       - run: codespell . --ignore-words-list=ba,referer --quiet-level=2
       - run: flake8 . --count --select=C,E5,E9,F4,F6,F7,F82 --max-complexity=43 --max-line-length=233 --show-source --statistics
@@ -48,4 +48,3 @@ jobs:
       - run: pytest tests
       - run: pytest test
       - run: scripts/run_doctests.sh
-      - run: safety check

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,35 +1,51 @@
-name: lint_python
+# https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
+name: python_tests
 on: [pull_request, push]
 jobs:
-  lint_python:
+  python_tests:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]  # 2.7
+        python-version: [3.9]
     runs-on: ubuntu-latest
+    services:
+      # Label does not set the Postgres host name which will be localhost
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: runner
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Map TCP port 5432 on service container to the host
+          - 5432:5432
     steps:
       - uses: actions/checkout@v2
-      - uses: harmon758/postgresql-action@v1
-        with:
-          postgresql version: '13'  # See https://hub.docker.com/_/postgres for available versions
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install bandit black codespell flake8 isort mypy psycopg2 pytest pyupgrade
-      - run: bandit -r . || true
+      - run: pip install black codespell flake8 isort mypy pytest pyupgrade safety
       - run: black --check . || true
       - run: codespell . --ignore-words-list=ba,referer --quiet-level=2
       - run: flake8 . --count --select=C,E5,E9,F4,F6,F7,F82 --max-complexity=43 --max-line-length=233 --show-source --statistics
       # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt
+      - run: pip install psycopg2 -r requirements.txt
       - run: mypy .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: psql -c 'create database infobase_test;' -U postgres || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
-      - run: pytest infogami -s || true
+      - run: shopt -s globstar && pyupgrade --py38-plus **/*.py || true
+      # web.py needs to find the database on a host named postgres
+      - run: echo "127.0.0.1 postgres" | sudo tee -a /etc/hosts
+      - run: psql --host=postgres --command='create database infobase_test;'  # MUST have a --host=
+      - run: pytest infogami -s
       - run: pytest tests
-      - run: pytest test || true
-      - run: source scripts/run_doctests.sh
+      - run: pytest test
+      - run: scripts/run_doctests.sh
+      - run: safety check

--- a/infogami/infobase/tests/utils.py
+++ b/infogami/infobase/tests/utils.py
@@ -3,7 +3,7 @@ from infogami.infobase import dbstore, client, server
 import os
 import web
 
-db_parameters = dict(dbn='postgres', db='infobase_test', user=os.getenv('USER'), pw='', pooling=False)
+db_parameters = dict(host='postgres', dbn='postgres', db='infobase_test', user=os.getenv('USER'), pw='', pooling=False)
 
 @web.memoize
 def recreate_database():
@@ -11,7 +11,8 @@ def recreate_database():
 
     This function is memoized to recreate the db only once per test session.
     """
-    assert os.system('dropdb infobase_test; createdb infobase_test') == 0
+    assert os.system('dropdb   --host=postgres infobase_test') == 0
+    assert os.system('createdb --host=postgres infobase_test') == 0
 
     db = web.database(**db_parameters)
 

--- a/test/test_dbstore.py
+++ b/test/test_dbstore.py
@@ -15,7 +15,7 @@ class InfobaseTestCase(unittest.TestCase):
 def site():
     #TODO: this does not clear data between tests. Make this work in scope=class
     user = os.getenv('USER')
-    web.config.db_parameters = dict(dbn='postgres', db='infobase_test', user=user, pw='')
+    web.config.db_parameters = dict(host='postgres', dbn='postgres', db='infobase_test', user=user, pw='')
     store = dbstore.DBStore(dbstore.Schema())
     store.db.printing = False
     ib = infobase.Infobase(store, 'secret')

--- a/test/webtest.py
+++ b/test/webtest.py
@@ -33,7 +33,7 @@ def runTests(suite):
     
 def main(suite=None):
     user = os.getenv('USER')
-    web.config.db_parameters = dict(dbn='postgres', db='infogami_test', user=user, pw='')
+    web.config.db_parameters = dict(host='postgres', dbn='postgres', db='infogami_test', user=user, pw='')
     web.load()
 
     delegate.app.request('/')


### PR DESCRIPTION
https://docs.github.com/en/actions/guides/creating-postgresql-service-containers

Initialize containers
* Waiting for all services to be ready
    * postgres service is healthy.
---
Run `psql --host=localhost --command='create database infobase_test;'`
```
CREATE DATABASE
```
So the GitHub Actions user `runner` can connect to postgres on localhost and create the `infobase_test` database. 👍 

But 👎 some tests that passed on Travis CI appear to fail to connect to that database...

---
test | Travis CI | GitHub Actions
--- | --- | ---
`pytest infogami` | Passes | __Fails__
`pytest tests` | Passes | Passes
`pytest test` | Passes | __Fails__
`source scripts/run_doctests.sh` | Passes | Passes