### PR TITLE
GitHub Actions: Make mypy a mandatory test 

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,12 +19,12 @@ jobs:
       - run: bandit -r . || true
       - run: black --check . || true
       - run: codespell . --ignore-words-list=ba,referer --quiet-level=2
-      - run: flake8 . --count --select=E9,F401,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --select=C,E5,E9,F4,F6,F7,F82 --max-complexity=43 --max-line-length=233 --show-source --statistics
       # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt
-      - run: mypy --ignore-missing-imports . || true
+      - run: mypy .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: psql -c 'create database infobase_test;' -U postgres || true
       - run: pytest . || true

--- a/infogami/core/forms.py
+++ b/infogami/core/forms.py
@@ -1,4 +1,7 @@
-from web.form import *
+from web.form import (Button, Checkbox, Form, Hidden, Password, Textbox,
+                      Validator, net, notnull, regexp)
+from web.form import *  # noqa: F40 TODO (cclauss): Remove wildcard imports
+
 
 from infogami.core import db
 from infogami.utils import i18n

--- a/infogami/utils/delegate.py
+++ b/infogami/utils/delegate.py
@@ -5,15 +5,17 @@ import web
 
 from infogami import config
 from infogami.utils import features, i18n
-from infogami.utils.app import *
+from infogami.utils.app import app, mode, page  # noqa: F401
+from infogami.utils.app import *  # noqa: F40 TODO (cclauss): Remove wildcard imports
 from infogami.utils.context import context
 from infogami.utils.view import render_site, public
+
 
 def create_site():
     from infogami.infobase import client
 
     if config.site is None:
-        site = web.ctx.host.split(':')[0] # strip port
+        site = web.ctx.host.split(':')[0]  # strip port
     else:
         site = config.site
 

--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -531,7 +531,7 @@ class HtmlBlockPreprocessor (Preprocessor):
                     left_tag = self._get_left_tag(block)
                     right_tag = self._get_right_tag(left_tag, block)
 
-                    if not (is_block_level(left_tag) \
+                    if not (is_block_level(left_tag)
                         or block[1] in ["!", "?", "@", "%"]):
                         new_blocks.append(block)
                         continue

--- a/migration/migrate-0.4-0.5.py
+++ b/migration/migrate-0.4-0.5.py
@@ -52,7 +52,7 @@ create index transaction_created_idx ON transaction(created);
 
 #@@ type to table prefix mappings. 
 #@@ If there are any special tables in your schema, this should be updated.
-type2table = {
+type2table = {  # type: ignore
 
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,39 @@
+# Global options:
+
+[mypy]
+ignore_missing_imports = True
+
+# Per-module options:
+
+[mypy-infogami.config]
+ignore_errors = True
+
+[mypy-infogami.core.forms]
+ignore_errors = True
+
+[mypy-infogami.infobase.bulkupload]
+ignore_errors = True
+
+[mypy-infogami.infobase.cache]
+ignore_errors = True
+
+[mypy-infogami.plugins.review.db]
+ignore_errors = True
+
+[mypy-infogami.utils.app]
+ignore_errors = True
+
+[mypy-infogami.utils.delegate]
+ignore_errors = True
+
+[mypy-infogami.utils.macro]
+ignore_errors = True
+
+[mypy-infogami.utils.storage]
+ignore_errors = True
+
+[mypy-infogami.utils.template]
+ignore_errors = True
+
+[mypy-sample_run]
+ignore_errors = True


### PR DESCRIPTION
Combine #150 with [mypy](https://mypy.readthedocs.io) excludes in `setup.cfg` so that our GitHub Actions can run `mypy .` on all future pull requests.