### PR TITLE
Avoid duplicate GitHub Actions run on PR/push

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,6 +1,10 @@
 # https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
 name: python_tests
-on: [pull_request, push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   python_tests:
     strategy:


### PR DESCRIPTION
This is what we have on open library; by default, GHA will run on every push + on every pull request modification, resulting in duplicate jobs.