### PR TITLE
refactor: Remove Python 2 test cases from test_dbstore

### DIFF
--- a/test/test_dbstore.py
+++ b/test/test_dbstore.py
@@ -3,8 +3,6 @@ import web
 import os
 import pytest
 
-from six import PY3
-
 from infogami.infobase import dbstore, infobase, common
 
 class InfobaseTestCase(unittest.TestCase):
@@ -44,28 +42,16 @@ class TestSaveTest():
         assert site.save('/foo', d) == {'key': '/foo', 'revision': 2}
 
     def new(self, site, error=None, **d):
-        # Dictionary ordering is different between Python 2 and Python 3.
-        # The py3_error key is the Python 2 error and the py3_error value is the Python 3 error
-        py3_error = {
-            '{"at": {"property": "type", "key": "/c"}, "key": "/type/noobject", "error": "notfound"}':
-            '{"error": "notfound", "key": "/type/noobject", "at": {"key": "/c", "property": "type"}}',
-            '{"error": "notfound", "key": "/type/noobject", "at": {"key": "/c", "property": "type"}}':
-            '{"at": {"property": "type", "key": "/c"}, "key": "/type/noobject", "error": "notfound"}',
-            '{"message": "invalid literal for int() with base 10: \'bad integer\'", "at": {"property": "i", "key": "/e1"}, "value": "bad integer", "error": "bad_data"}':
-            '{"error": "bad_data", "message": "invalid literal for int() with base 10: \'bad integer\'", "at": {"key": "/e1", "property": "i"}, "value": "bad integer"}'
-        }
         try:
             key = d['key']
             assert site.save(key, d) == {'key': key, 'revision': 1}
         except common.InfobaseException as e:
-            if PY3:
-                error = py3_error[error]
             assert str(e) == error, (str(e), error)
 
     def test_type(self, site):
         self.new(site, key='/a', type='/type/object')
         self.new(site, key='/b', type={'key': '/type/object'})
-        self.new(site, key='/c', type='/type/noobject', error='{"at": {"property": "type", "key": "/c"}, "key": "/type/noobject", "error": "notfound"}')
+        self.new(site, key='/c', type='/type/noobject', error='{"error": "notfound", "key": "/type/noobject", "at": {"key": "/c", "property": "type"}}')
 
     def test_expected_type(self, site):
         def p(name, expected_type, unique=True):
@@ -74,7 +60,7 @@ class TestSaveTest():
 
         self.new(site, key='/aa', type='/type/test', i='1', f='1.2', t='/type/test')
         self.new(site, key='/bb', type='/type/test', i={'type': '/type/int', 'value': '1'}, f='1.2', t={'key': '/type/test'})
-        self.new(site, key='/e1', type='/type/test', i='bad integer', error='{"message": "invalid literal for int() with base 10: \'bad integer\'", "at": {"property": "i", "key": "/e1"}, "value": "bad integer", "error": "bad_data"}')
+        self.new(site, key='/e1', type='/type/test', i='bad integer', error='{"error": "bad_data", "message": "invalid literal for int() with base 10: \'bad integer\'", "at": {"key": "/e1", "property": "i"}, "value": "bad integer"}')
 
     @pytest.mark.skip(reason="d is expected to be json (DBSiteStore.get()), but is actually a string from DBStore.get()")
     def test_embeddable_types(self, site):


### PR DESCRIPTION
Given that the codebase no longer supports legacy Python, the test cases used to test on both Python 2 and 3 are now only expected to be tested on Python 3.

To fix the failing tests for #162.

This PR should be merged first before #162 to allow me to rebase.