### PR TITLE
refactor: Upgrade pip in GitHub actions

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ~/infogami_python_venv/bin/activate
+          pip install --upgrade pip
           pip install -r requirements_test.txt
       - name: Run tests
         run: |


### PR DESCRIPTION
We should keep `pip` up-to date on our GitHub actions.