### PR TITLE
Define repr(Nothing()) and str(Nothing())

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -640,12 +640,14 @@ class Nothing:
     """For representing missing values.
 
     >>> n = Nothing()
+    >>> repr(n)
+    '<Nothing>'
     >>> str(n)
-    '<Nothing>'
+    ''
     >>> web.safestr(n)
-    '<Nothing>'
+    ''
     >>> str([n])  # See #148 and #151
-    '[<Nothing>]'
+    '[]'
     """
     def __getattr__(self, name):
         if name.startswith('__') or name == 'next':
@@ -685,6 +687,9 @@ class Nothing:
 
     def __repr__(self):
         return "<Nothing>"
+
+    def __str__(self):
+        return ""
 
 nothing = Nothing()
 

--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -647,7 +647,7 @@ class Nothing:
     >>> web.safestr(n)
     ''
     >>> str([n])  # See #148 and #151
-    '[]'
+    '[<Nothing>]'
     """
     def __getattr__(self, name):
         if name.startswith('__') or name == 'next':


### PR DESCRIPTION
As we saw during yesterday's deployment, we need empty fields to remain empty.

This PR must land just _after_ internetarchive/openlibrary#5020 has landed (so this PRs tests will pass) because the two PRs are linked and tests will fail until both are landed.

@dhruvmanila 