### PR TITLE
chore: Add .git-blame-ignore-revs for git blame command

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,16 @@
+# This file is used to ignore specific commit revision for `git blame`. It
+# contains a list of commits that are not likely what you are looking for in a
+# blame, such as mass reformatting or renaming. It can be used by any of the
+# following ways:
+#
+# - Include the file in the command:
+#      $ git blame --ignore-revs-file .git-blame-ignore-revs <other options>
+#
+# - Through gitconfig (needs to be set per-project):
+#      $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Each commit has to be the full 40 character hash and comments are allowed.
+# Required git version: 2.23
+
+# Format the entire codebase through black (PR #162)
+42acd0ae22c27659959788fdbc82d89a4c35afd4


### PR DESCRIPTION
Add `.git-blame-ignore-revs` which will be used to store the hashes for commits which create mass changes to the codebase and is mostly done through some external tool. This will help keep our blame history sane.

@cclauss 