### PR TITLE
fix: GitHub action run scripts

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -88,11 +88,11 @@ class Connection:
         try:
             data = json.loads(error)
             message = data.get('message', data.get('error', ''))
-            json = error
+            json_data = error
         except Exception as e:
             message = error or str(e)
-            json = None
-        raise ClientException(status, message, json)
+            json_data = None
+        raise ClientException(status, message, json_data)
 
 
 class LocalConnection(Connection):

--- a/scripts/run_python_linters.sh
+++ b/scripts/run_python_linters.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # Used for GitHub actions
+set -e
 
 # Run linters and formatters
 black --skip-string-normalization --check .
 codespell . --ignore-words-list=ba,referer --quiet-level=2
-flake8 .
-  \ --count
-  \ --select=C,E5,E9,F4,F6,F7,F82
-  \ --max-complexity=43
-  \ --max-line-length=233
-  \ --show-source
-  \ --statistics
+flake8 . \
+  --count \
+  --select=C,E5,E9,F4,F6,F7,F82 \
+  --max-complexity=43 \
+  --max-line-length=233 \
+  --show-source \
+  --statistics
 # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # FIXME: Remove `|| true` once the code is isort compliant

--- a/scripts/run_python_linters.sh
+++ b/scripts/run_python_linters.sh
@@ -2,7 +2,7 @@
 # Used for GitHub actions
 
 # Run linters and formatters
-black --check .
+black --skip-string-normalization --check .
 codespell . --ignore-words-list=ba,referer --quiet-level=2
 flake8 .
   \ --count

--- a/scripts/run_python_tests.sh
+++ b/scripts/run_python_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Used for GitHub actions
+set -e
 
 # web.py needs to find the database on a host named postgres
 echo "127.0.0.1 postgres" | sudo tee -a /etc/hosts

--- a/test/test_dbstore.py
+++ b/test/test_dbstore.py
@@ -69,6 +69,7 @@ class TestSaveTest:
     def test_expected_type(self, site):
         def p(name, expected_type, unique=True):
             return locals()
+
         self.new(
             site,
             key='/type/test',


### PR DESCRIPTION
Sorry about the misplacement of backslash. That's how it was in `vimscript` :)

We should be using `set -e` flag to exit immediately if any of the commands fail to easily debug where the problem lies. Without this, our GitHub action would give false-positives (tests are passing, but there are errors in the files)

@cclauss I think this is the reason, https://github.com/internetarchive/infogami/pull/168/checks?check_run_id=2313436147 got stuck at `run tests` step. Please restart the tests once this PR merges.