### PR TITLE
Use current_thread instead of currentThread method that was deprecated in Python 3.10.

### DIFF
--- a/test/test_infobase.py
+++ b/test/test_infobase.py
@@ -66,7 +66,7 @@ class InfobaseTestCase(unittest.TestCase):
     def clear_threadlocal(self):
         import threading
 
-        t = threading.currentThread()
+        t = threading.current_thread()
         if hasattr(t, '_d'):
             del t._d
 


### PR DESCRIPTION
Ref : https://github.com/internetarchive/openlibrary/pull/5157#pullrequestreview-656252039