### PR TITLE
Update @jsonapi to use functools.wraps

### DIFF
--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -1,12 +1,14 @@
 """
 Infogami read/write API.
 """
+import json
+from functools import wraps
+
 import web
 import infogami
 from infogami.utils import delegate, features
 from infogami.utils.view import safeint
 from infogami.infobase import client
-import json
 
 hooks = {}
 
@@ -139,6 +141,7 @@ add_hook("save_many", infobase_request)
 
 
 def jsonapi(f):
+    @wraps(f)
     def g(*a, **kw):
         try:
             out = f(*a, **kw)
@@ -157,7 +160,6 @@ def jsonapi(f):
 
         return delegate.RawText(out, content_type=content_type)
 
-    g.__doc__ = f.__doc__  # Preserve docstrings for the inspect module
     return g
 
 


### PR DESCRIPTION
Provides a more complete solution to https://github.com/internetarchive/infogami/commit/12f6c18a07c9408513d1580ec63f09390fd2402e

In internetarchive/openlibrary#5910 we want to use Python's `inspect` module to access the `method.__code__` and `method.__doc__` variables but @decorators block such access unless we use https://docs.python.org/3/library/functools.html#functools.wraps