### PR TITLE
Allow maintainers to run CI tests on-demand

### DIFF
--- a/.github/workflows/openlibrary_tests.yml
+++ b/.github/workflows/openlibrary_tests.yml
@@ -4,6 +4,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 jobs:
   openlibrary_tests:
     strategy:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 jobs:
   python_tests:
     strategy:


### PR DESCRIPTION
Add `workflow_dispatch` run option...
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/