### PR TITLE
Detect RecursionError in Markdown._processSection()

### DIFF
--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -1338,7 +1338,10 @@ class Markdown:
             if theRest:
                 theRest = theRest[1:]  # skip the first (blank) line
 
-            self._processSection(parent_elem, theRest, inList)
+            try:
+                self._processSection(parent_elem, theRest, inList)
+            except RecursionError as e:
+                message(CRITICAL, repr(e))
 
     def _processUList(self, parent_elem, lines, inList):
         self._processList(parent_elem, lines, inList, listexpr='ul', tag='ul')


### PR DESCRIPTION
Fixes internetarchive/openlibrary#3926

https://docs.python.org/3/library/exceptions.html#RecursionError

Detect the error and issue a critical message containing the error but allow processing to continue.

@SouthGoingZax Your review, please...