### PR TITLE
Fix infogami errors appearing as 503 unavailable

### DIFF
--- a/infogami/infobase/client.py
+++ b/infogami/infobase/client.py
@@ -161,10 +161,8 @@ class RemoteConnection(Connection):
             response = requests.request(
                 method, f'http://{self.base_url}{path}', data=data, headers=headers
             )
-            if not response.ok:
-                response.raise_for_status()
             stats.end()
-        except requests.exceptions.HTTPError:
+        except requests.exceptions.ConnectionError:
             stats.end(error=True)
             logger.error("Unable to connect to infobase server", exc_info=True)
             raise ClientException(


### PR DESCRIPTION
Work towards #5185 -- this won't close it, but it'll make it display a _real_ error.

Previously when we used http_client, this only caught connection errors--there's code below the except block that handled non-200 return statuses.

Testing:

- Open up a gitpod instance
- kill running instance in terminal `ctrl-c`
- Pull down this branch: `cd vendor/infogami && git pull https://github.com/cdrini/infogami.git fix/infogami-errors-muted && cd -`
- Start with infogami volume mounted: `COMPOSE_FILE="docker-compose.yml:docker-compose.override.yml:docker-compose.infogami-local.yml" docker-compose up -d`

Note any subsequent changes to infogami code just need a restart of web and infogami. But don't forget the `COMPOSE_FILE`!