### PR TITLE
Fix un-html escaped hrefs causing XSS

### DIFF
--- a/infogami/core/macros/PageList.html
+++ b/infogami/core/macros/PageList.html
@@ -10,8 +10,8 @@ $for p in pages:
 
 <div>
 $if page != 0:
-    &larr; <a href="$:changequery(page=page - 1)">Prev</a>
+    &larr; <a href="$changequery(page=page - 1)">Prev</a>
 
 $if len(pages) == limit:
-    ... <a href="$:changequery(page=page + 1)">Next</a> &rarr;
+    ... <a href="$changequery(page=page + 1)">Next</a> &rarr;
 </div>

--- a/infogami/core/macros/RecentChanges.html
+++ b/infogami/core/macros/RecentChanges.html
@@ -37,9 +37,9 @@ $for v in changes:
 
 <div>
 $if page != 0:
-    <a href="$:changequery(rc_page=page - 1)">Newer</a>
+    <a href="$changequery(rc_page=page - 1)">Newer</a>
 
 $if len(changes) == limit:
-    <a href="$:changequery(rc_page=page + 1)">Older</a>
+    <a href="$changequery(rc_page=page + 1)">Older</a>
 <div>
 

--- a/infogami/core/templates/permission_denied.html
+++ b/infogami/core/templates/permission_denied.html
@@ -7,4 +7,4 @@ $error
 <br/><br/>
 
 $if not ctx.user:
-	You may <a href="/account/login?$:urlencode(dict(redirect=path))">Login</a> if you have the required permissions.
+	You may <a href="/account/login?$urlencode(dict(redirect=path))">Login</a> if you have the required permissions.

--- a/infogami/plugins/i18n/templates/i18n.html
+++ b/infogami/plugins/i18n/templates/i18n.html
@@ -21,7 +21,7 @@ Language: $:Dropdown('lang', _.get_languages(), onchange="changelang();", value=
 <tr>
 <td style="vertical-align: top">
 $for ns in _.get_namespaces():
-    <a href="$:changequery(ns=ns)" >$(ns or "root")</a> <span id="count" style="font-size: 0.8em; ">$(_.get_count(ns, lang))/$_.get_count(ns)</span> <br/>
+    <a href="$changequery(ns=ns)" >$(ns or "root")</a> <span id="count" style="font-size: 0.8em; ">$(_.get_count(ns, lang))/$_.get_count(ns)</span> <br/>
 </td>
 <td style="vertical-align: top">
 $if page:


### PR DESCRIPTION
You are allowed to html encode `&` in urls to `&amp;` when writing out the `href`.