### PR TITLE
PEP8: Do not use bare except:

### DIFF
--- a/infogami/core/dbupgrade.py
+++ b/infogami/core/dbupgrade.py
@@ -35,7 +35,7 @@ def apply_upgrades():
         mark_upgrades()
         tdb.commit()
         print('upgrade successful.', file=web.debug)
-    except:
+    except Exception:
         print('upgrade failed', file=web.debug)
         import traceback
 
@@ -63,7 +63,7 @@ def hash_passwords():
     for u in users:
         try:
             preferences = u._c('preferences')
-        except:
+        except Exception:
             # setup preferences for broken accounts, so that they can use forgot password.
             preferences = db.new_version(
                 u, 'preferences', db.get_type(ctx.site, 'type/thing'), dict(password='')

--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -72,7 +72,7 @@ class SaveImpl:
             self.db.multiple_insert('data', data, seqname=False)
 
             self._update_index(records)
-        except:
+        except Exception:
             dbtx.rollback()
             raise
         else:
@@ -126,7 +126,7 @@ class SaveImpl:
         tx = self.db.transaction()
         try:
             self.indexUtil.update_index(records)
-        except:
+        except Exception:
             tx.rollback()
             raise
         else:
@@ -193,7 +193,7 @@ class SaveImpl:
                 + " FOR UPDATE NOWAIT",
                 vars=locals(),
             )
-        except:
+        except Exception:
             raise common.Conflict(keys=keys, reason="Edit conflict detected.")
 
         records = {r.key: r for r in rows}

--- a/infogami/infobase/_dbstore/sequence.py
+++ b/infogami/infobase/_dbstore/sequence.py
@@ -33,7 +33,7 @@ class SequenceImpl:
             else:
                 value = 1
                 self.db.insert("seq", name=name, value=value)
-        except:
+        except Exception:
             tx.rollback()
             raise
         else:
@@ -50,7 +50,7 @@ class SequenceImpl:
                 self.db.update("seq", value=value, where="name=$name", vars=locals())
             else:
                 self.db.insert("seq", name=name, value=value)
-        except:
+        except Exception:
             tx.rollback()
             raise
         else:

--- a/infogami/infobase/_dbstore/store.py
+++ b/infogami/infobase/_dbstore/store.py
@@ -112,7 +112,7 @@ class Store:
 
             doc['_key'] = key
             doc['_rev'] = str(id)
-        except:
+        except Exception:
             tx.rollback()
             raise
         else:
@@ -139,7 +139,7 @@ class Store:
                 if rev is not None and str(row.id) != str(rev):
                     raise common.Conflict(key=key, message="Document update conflict")
                 self.delete_row(row.id)
-        except:
+        except Exception:
             tx.rollback()
             raise
         else:

--- a/infogami/infobase/account.py
+++ b/infogami/infobase/account.py
@@ -61,7 +61,7 @@ class AccountManager:
             self.store_account_info(username, email, enc_password, data)
             if _activate:
                 self.activate(username)
-        except:
+        except Exception:
             logger.error(
                 "Failed to store registration info. username=%s",
                 username,

--- a/infogami/infobase/dbstore.py
+++ b/infogami/infobase/dbstore.py
@@ -593,7 +593,7 @@ class DBSiteStore(common.SiteStore):
         t = self.db.transaction()
         try:
             f()
-        except:
+        except Exception:
             t.rollback()
             raise
         else:
@@ -662,7 +662,7 @@ class DBStore(common.Store):
         try:
             self.db.select('thing', limit=1)
             return True
-        except:
+        except Exception:
             return False
 
     def create(self, sitename):
@@ -707,7 +707,7 @@ class MultiDBStore(DBStore):
             sitestore = MultiDBSiteStore(self.db, self.schema, sitename, site_id)
             sitestore.initialize()
             self.sitestores[sitename] = sitestore
-        except:
+        except Exception:
             t.rollback()
             raise
         else:

--- a/infogami/infobase/infobase.py
+++ b/infogami/infobase/infobase.py
@@ -72,7 +72,7 @@ class Infobase:
         for listener in self.event_listeners:
             try:
                 listener(event)
-            except:
+            except Exception:
                 common.record_exception()
                 pass
 
@@ -309,7 +309,7 @@ class Site:
             for t in triggers:
                 try:
                     t(self, old, new)
-                except:
+                except Exception:
                     print('Failed to execute trigger', t, file=web.debug)
                     import traceback
 

--- a/infogami/infobase/server.py
+++ b/infogami/infobase/server.py
@@ -175,7 +175,7 @@ def input(*required, **defaults):
 def to_int(value, key):
     try:
         return int(value)
-    except:
+    except Exception:
         raise common.BadData(
             message=f"Bad integer value for {repr(key)}: {repr(value)}"
         )

--- a/infogami/infobase/tests/utils.py
+++ b/infogami/infobase/tests/utils.py
@@ -50,7 +50,7 @@ def teardown_db(mod):
     mod.db.ctx.clear()
     try:
         del mod.db
-    except:
+    except Exception:
         pass
 
 
@@ -65,7 +65,7 @@ def teardown_conn(mod):
     teardown_db(mod)
     try:
         del mod.conn
-    except:
+    except Exception:
         pass
 
 
@@ -83,7 +83,7 @@ def teardown_server(mod):
 
     try:
         del mod.site
-    except:
+    except Exception:
         pass
 
 

--- a/infogami/plugins/pages/code.py
+++ b/infogami/plugins/pages/code.py
@@ -80,7 +80,7 @@ def _savepage(page, create_dependents=True, comment=None):
             return name
         try:
             return db.get_version(context.site, name)
-        except:
+        except Exception:
             if create and create_dependents:
                 thing = db.new_version(context.site, name, getthing("type/thing"), {})
                 thing.save()
@@ -187,7 +187,7 @@ def _pushpages(pages):
         for p in pages.values():
             print('saving', p.name)
             _savepage(p)
-    except:
+    except Exception:
         tdb.rollback()
         raise
     else:
@@ -293,7 +293,7 @@ def dataload(filename):
         for line in lines:
             data = storify(eval(line))
             _savepage(data)
-    except:
+    except Exception:
         tdb.rollback()
         raise
     else:

--- a/infogami/plugins/review/db.py
+++ b/infogami/plugins/review/db.py
@@ -48,7 +48,7 @@ class SQL:
                 user_id=user_id,
                 revision=revision,
             )
-        except:
+        except Exception:
             web.rollback()
             raise
         else:

--- a/infogami/plugins/wikitemplates/code.py
+++ b/infogami/plugins/wikitemplates/code.py
@@ -225,7 +225,7 @@ def movetemplates(prefix_pattern=None):
         if isinstance(t, LazyTemplate):
             try:
                 t.func()
-            except:
+            except Exception:
                 print('unable to load template', t.name, file=web.debug)
                 raise
 

--- a/infogami/utils/i18n.py
+++ b/infogami/utils/i18n.py
@@ -117,7 +117,7 @@ class i18n_string:
         try:
             a = [x or "" for x in a]
             return str(self) % tuple(web.safestr(x) for x in a)
-        except:
+        except Exception:
             traceback.print_exc()
             print(
                 'failed to substitute (%s/%s) in language %s'
@@ -159,7 +159,7 @@ def i18n_loadhook():
         web.ctx.lang = (
             parse_query_string() or parse_lang_cookie() or parse_lang_header() or ''
         )
-    except:
+    except Exception:
         traceback.print_exc()
         web.ctx.lang = None
 
@@ -208,7 +208,7 @@ def load_strings(plugin_path):
             namespace, lang = parse_path(dirstrip(p, root))
             data = read_strings(p)
             strings._update_strings(namespace, lang, data)
-        except:
+        except Exception:
             traceback.print_exc()
             print("failed to load strings from", p, file=web.debug)
 

--- a/infogami/utils/markdown/markdown.py
+++ b/infogami/utils/markdown/markdown.py
@@ -1150,7 +1150,7 @@ class Markdown:
             try:
                 module = __import__(extension_module_name)
 
-            except:
+            except Exception:
                 message(
                     CRITICAL,
                     "couldn't load extension %s (looking for %s module)"
@@ -1760,7 +1760,7 @@ def parse_options():
 
     try:
         optparse = __import__("optparse")
-    except:
+    except Exception:
         if len(sys.argv) == 2:
             return {
                 'input': sys.argv[1],

--- a/scripts/run_python_linters.sh
+++ b/scripts/run_python_linters.sh
@@ -5,7 +5,7 @@ set -e -v
 # Run linters and formatters
 black --skip-string-normalization --check .
 codespell --ignore-words-list=asend,alo,ba,spawnve
-flake8 . --count --ignore=E203,E402,E722,E731,F811,F841,W503 \
+flake8 . --count --ignore=E203,E402,E731,F811,F841,W503 \
          --max-complexity=43 --max-line-length=175 --show-source --statistics
 # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ skip = *.json
 # E203 and W503 are for psf/black
 # max-line-length should be 88
 # max-complexity should be 10
-ignore = E203,E402,E722,E731,F811,F841,W503
+ignore = E203,E402,E731,F811,F841,W503
 max-line-length = 175
 max-complexity = 43
 show-source = True


### PR DESCRIPTION
Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.
Prefer `except Exception:`. If you’re sure what you’re doing, be explicit and write `except BaseException:`. 
* https://github.com/PyCQA/flake8-bugbear#list-of-warnings
* https://realpython.com/the-most-diabolical-python-antipattern