### PR TITLE
Modified POST function in code.py

### DIFF
--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -101,8 +101,8 @@ class infobase_request:
 
         query = web.data()
         h = get_custom_headers()
-        comment = h.get('comment')
-        action = h.get('action')
+        data = {key: h.get(key) for key in ('action', 'comment', 'data')}
+        data['query'] = query
         qdata = h.get('data')
         data = dict(query=query, comment=comment, action=action, data=qdata)
 

--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -103,8 +103,6 @@ class infobase_request:
         h = get_custom_headers()
         data = {key: h.get(key) for key in ('action', 'comment', 'data')}
         data['query'] = query
-        qdata = h.get('data')
-        data = dict(query=query, comment=comment, action=action, data=qdata)
 
         conn = self.create_connection()
 

--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -103,7 +103,8 @@ class infobase_request:
         h = get_custom_headers()
         comment = h.get('comment')
         action = h.get('action')
-        data = dict(query=query, comment=comment, action=action)
+        qdata = h.get('data')
+        data = dict(query=query, comment=comment, action=action, data=qdata)
 
         conn = self.create_connection()
 


### PR DESCRIPTION
Infogami's save_many method supports a data parameter, along with the query, comment, and action parameters, but the POST API defined here doesn't recognize the data parameter. This change makes the POST API consistent with the save_many parameters.

This change is necessary to implement Open Library work merge undo.

See https://github.com/internetarchive/openlibrary/pull/6948 for OL Side

### Stakeholders
@mheiman @cdrini
