### PR TITLE
Fix * in accept lang causing errors

### DIFF
--- a/infogami/utils/i18n.py
+++ b/infogami/utils/i18n.py
@@ -139,7 +139,7 @@ def i18n_loadhook():
 
         # take just the language part. ignore other details.
         # for example `en-gb;q=0.8` will be treated just as `en`.
-        langs = [t[:2] for t in tokens]
+        langs = [t[:2] for t in tokens if not t.startswith('*')]
         return langs and langs[0]
 
     def parse_lang_cookie():


### PR DESCRIPTION
Fix most common sentry error https://sentry.archive.org/organizations/ia-ux/issues/42677

Tested with a FF extension to set the header, and it worked correctly with:
- `fr`
- `*`
- `*, fr`
- `de, *`