### PR TITLE
Upgrade to Python 3.11 to match Open Libary

### DIFF
--- a/.github/workflows/openlibrary_tests.yml
+++ b/.github/workflows/openlibrary_tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     runs-on: ubuntu-latest
     steps:
       # - if: "contains(matrix.python-version, '-dev')"

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     runs-on: ubuntu-latest
     services:
       # Label does not set the Postgres host name which will be localhost

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     license="AGPLv3",


### PR DESCRIPTION
No need to run tests on Python 3.10 anymore because Open Library has upgraded to 3.11.1.