### PR TITLE
Add Python 3.12-dev to the testing

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12-dev"]
     runs-on: ubuntu-latest
     services:
       # Label does not set the Postgres host name which will be localhost
@@ -32,8 +32,8 @@ jobs:
           # Map TCP port 5432 on service container to the host
           - 5432:5432
     steps:
-      # - if: "contains(matrix.python-version, '-dev')"
-      #  run: sudo apt-get install -y libxml2 libxslt-dev
+      - if: "contains(matrix.python-version, '-dev')"
+        run: sudo apt-get install -y libxml2 libxslt-dev
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
We are halfway thru the Python 3.12 alpha cycle so let's see if any of the proposed changes break our tests...
* https://peps.python.org/pep-0693/#release-schedule
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3120a4/