### PR TITLE
Reset 'pd' (internetarchive/openlibrary#8005)

### DIFF
--- a/infogami/core/code.py
+++ b/infogami/core/code.py
@@ -288,6 +288,7 @@ class logout(delegate.page):
     path = "/account/logout"
 
     def POST(self):
+        web.setcookie('pd', "", expires=-1)
         web.setcookie(config.login_cookie_name, "", expires=-1)
         referer = web.ctx.env.get('HTTP_REFERER', '/')
         raise web.seeother(referer)


### PR DESCRIPTION
This resets the printdisabled cookies when logging out for any user by setting it to expire and be deleted upon logging out as any user, effectively fixing the mentioned issue.