### PR TITLE
Feature: `~` uses `ILIKE` rather than `LIKE`

### DIFF
--- a/infogami/infobase/core.py
+++ b/infogami/infobase/core.py
@@ -237,7 +237,6 @@ class SiteStore:
         """Initializes the store for the first time.
         This is called before doing the bootstrap.
         """
-        ...
 
     def set_cache(self, cache):
         pass

--- a/infogami/infobase/dbstore.py
+++ b/infogami/infobase/dbstore.py
@@ -291,8 +291,11 @@ class DBSiteStore(common.SiteStore):
                     raise StopIteration
                 c.value = metadata.id
             if c.op == '~':
-                op = Literal('LIKE')
-                c.value = c.value.replace('*', '%').replace('_', r'\_')
+                op = Literal('ILIKE')
+                # Asterisks as part of the author's name query from patron input are escaped in Open Library
+                # so they don't become % wild card searches. E.g. an author styled as "Muñ*z" shouldn't have
+                # their "*" become a wild card. Other wild cards added by code should be converted to %, though.
+                c.value = r'\*'.join(part.replace('*', '%') for part in c.value.split(r'\*')).replace('_', r'\_')
             else:
                 op = Literal(c.op)
 


### PR DESCRIPTION
Related: internetarchive/openlibrary#7349

Using `~` on a query field (e.g. `name~`) will do a PostgreSQL `ILIKE`, rather than a `LIKE`, query.

Note: because of https://github.com/internetarchive/openlibrary/issues/137 `_` will not work as expected, though `%` will.