### PR TITLE
Prioritize macros above other inline patterns

### DIFF
--- a/infogami/utils/macro.py
+++ b/infogami/utils/macro.py
@@ -154,7 +154,7 @@ def replace_macros(html, macros):
 
 class MacroExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
-        md.inlinePatterns.append(MacroPattern(md))
+        md.inlinePatterns.insert(0, MacroPattern(md))
         md.macro_count = 0
         md.macros = {}
 


### PR DESCRIPTION
Closes: https://github.com/internetarchive/openlibrary/issues/9036

**Problem:**
Currently, including an  inline pattern within a macro breaks the whole process; this is untenable, since it means that escaping a character in an argument renders it wholly unworkable. 

**Solution**:
This fix places macros at the beginning of the list of inline patterns, prioritizing them above inline patterns. This has no effect on anything outside of macros, so there should be no negative side effects. Breaking up the ```{{function()}}```  pattern into ```\{\{function()\}\}``` still allows for the code to be typed, but not executed. 

**Testing:**
Play around with the macros in a  custom page. In the live version, escaping a character within the arguments prevents it from working, but it should be functional now. 