### PR TITLE
Update default transaction types

### DIFF
--- a/infogami/infobase/dbstore.py
+++ b/infogami/infobase/dbstore.py
@@ -158,7 +158,7 @@ class DBSiteStore(common.SiteStore):
 
     def save_many(self, docs, timestamp, comment, data, ip, author, action=None):
         docs = list(docs)
-        action = action or "bulk_update"
+        action = action or "default-bulk-update"
         logger.debug(
             "saving %d docs - %s",
             len(docs),
@@ -210,7 +210,7 @@ class DBSiteStore(common.SiteStore):
         logger.debug("saving %s", key)
         timestamp = timestamp or datetime.datetime.utcnow
         return self.save_many(
-            [doc], timestamp, comment, data, ip, author, action=action or "update"
+            [doc], timestamp, comment, data, ip, author, action=action or "default-update"
         )
 
     def reindex(self, keys):

--- a/infogami/infobase/tests/test_client.py
+++ b/infogami/infobase/tests/test_client.py
@@ -34,7 +34,7 @@ class TestRecentChanges:
         assert changes == [
             {
                 "id": wildcard,
-                "kind": "update",
+                "kind": "default-update",
                 "author": None,
                 "ip": wildcard,
                 "timestamp": wildcard,
@@ -46,7 +46,7 @@ class TestRecentChanges:
 
         assert site.get_change(changes[0]["id"]).dict() == {
             "id": wildcard,
-            "kind": "update",
+            "kind": "default-update",
             "author": None,
             "ip": wildcard,
             "timestamp": wildcard,


### PR DESCRIPTION
Marked as "Draft" until consensus is reached (and until tests are fixed).

Updates the default `save` and `save_many` transaction `action` to `default-update` and `default-bulk-update`, respectively.  With these changes in place, we can easily query the `transaction` table and determine if `save` or `save_many` is being called w/o an `action`.

It would be best if it were deployed at the same time as https://github.com/internetarchive/openlibrary/pull/12058.