### PR TITLE
fix(betterlist): skip non-numeric indices to prevent ValueError on language page save

### DIFF
--- a/infogami/core/helpers.py
+++ b/infogami/core/helpers.py
@@ -86,7 +86,24 @@ class betterlist(list):
             self.append(None)
 
     def setdefault(self, index, value):
-        index = int(index)
+        """Set a value at the given index, expanding the list as needed.
+
+        Non-numeric indices (e.g. template placeholders like
+        '[row_translated_names]') are silently ignored so that unprocessed
+        repetition-widget rows do not crash form submission.
+
+        >>> bl = betterlist()
+        >>> bl.setdefault('0', 'a')
+        'a'
+        >>> bl.setdefault('[row_translated_names]', 'x') is None
+        True
+        >>> bl  # list is unchanged after non-numeric index
+        ['a']
+        """
+        try:
+            index = int(index)
+        except (ValueError, TypeError):
+            return None
         self.fill(index + 1)
         if self[index] is None:
             self[index] = value


### PR DESCRIPTION
Fixes internetarchive/openlibrary#11981

## What changed
`betterlist.setdefault()` in `infogami/core/helpers.py` called `int(index)`
unconditionally. When the repetition widget in `default_edit.html` submits
unprocessed template placeholder rows (e.g. `translated_names#[row_translated_names]`),
`unflatten()` passes the placeholder string as the index, causing:

    ValueError: invalid literal for int() with base 10: '[row_translated_names]'

This crash made language page editing completely broken via the UI for superusers.

## Fix
Wrapped `int(index)` in a `try/except (ValueError, TypeError)` block.
Non-numeric indices are silently skipped (return `None`) — they are always invalid
in a list context and represent unrendered template rows that should be ignored.
All valid numeric indices continue to work exactly as before.

## Tests
Added 3 doctests to `betterlist.setdefault()` covering:
- normal numeric index (existing behaviour)
- placeholder string `'[row_translated_names]'` → returns `None`
- list remains unchanged after skipped index

All 15 existing doctests in `infogami/core/helpers.py` pass.
