### PR TITLE
Add `transaction_details` table

### DIFF
--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -130,7 +130,7 @@ class SaveImpl:
 
         d = []
 
-        def append_rows(records: list[tuple], action_type: str) -> None:
+        def append_rows(records: set[tuple], action_type: str) -> None:
             for r in records:
                 d.append(
                     {

--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -72,7 +72,10 @@ class SaveImpl:
             ]
             self.db.multiple_insert('data', data, seqname=False)
 
-            self._update_index(records)
+            deletes, inserts = self._update_index(records)
+
+            if config.use_transaction_details_table:
+                self._add_transaction_details(deletes, inserts, tx_id, author, bot)
         except Exception:
             dbtx.rollback()
             raise
@@ -116,6 +119,37 @@ class SaveImpl:
         if d:
             self.db.multiple_insert("transaction_index", d, seqname=False)
 
+    def _add_transaction_details(self, deletes: dict, inserts: dict, txn_id: int, author_key: str, is_bot: bool) -> None:
+        delete_keys = deletes.keys()
+        insert_keys = inserts.keys()
+        author_id = self.thing_ids[author_key]
+
+        updates = delete_keys & insert_keys
+        removes = delete_keys - insert_keys
+        creates = insert_keys - delete_keys
+
+        d = []
+
+        def append_rows(records: list[tuple], action_type: str) -> None:
+            for r in records:
+                d.append(
+                    {
+                        "transaction_id": txn_id,
+                        "thing_id": r[1],
+                        "key_id": r[2],
+                        "author_id": author_id,
+                        "is_bot": is_bot,
+                        "property_action": action_type,
+                    }
+                )
+
+        append_rows(updates, "update")
+        append_rows(removes, "delete")
+        append_rows(creates, "create")
+
+        if d:
+            self.db.multiple_insert("transaction_details", d)
+
     def reindex(self, keys):
         records = self._load_records(keys).values()
 
@@ -134,7 +168,7 @@ class SaveImpl:
             tx.commit()
 
     def _update_index(self, records):
-        self.indexUtil.update_index(records)
+        return self.indexUtil.update_index(records)
 
     def dedupe(self, docs):
         x = set()
@@ -420,6 +454,8 @@ class IndexUtil:
 
         self.delete_index(deletes)
         self.insert_index(inserts)
+
+        return deletes, inserts
 
     def compile_index(self, index):
         """Compiles doc-index into db-index."""

--- a/infogami/infobase/_dbstore/schema.sql
+++ b/infogami/infobase/_dbstore/schema.sql
@@ -79,6 +79,17 @@ RETURNS text AS
 'select property.name FROM property, thing WHERE thing.type = property.type AND thing.id=$$1 AND property.id=$$2;'
 LANGUAGE SQL;
 
+create table transaction_details (
+    id serial primary key,
+    transaction_id integer references transaction(id),
+    thing_id integer references thing(id),
+    key_id integer references property(id),
+    property_action text,
+    author_id integer references thing(id),
+    is_bot boolean,
+    created timestamp without time zone default (current_timestamp at time zone 'utc')
+);
+
 create table account (
     $if multisite:
         site_id int references site,

--- a/infogami/infobase/config.py
+++ b/infogami/infobase/config.py
@@ -33,7 +33,7 @@ use_machine_comment = False
 use_bot_column = True
 
 # Store additional transaction metadata in the `transaction_details` table
-use_transaction_details_table = True
+use_transaction_details_table = False
 
 verify_user_email = False
 

--- a/infogami/infobase/config.py
+++ b/infogami/infobase/config.py
@@ -32,6 +32,9 @@ use_machine_comment = False
 # bot column is added transaction table to mark edits by bot. Flag to enable/disable this feature.
 use_bot_column = True
 
+# Store additional transaction metadata in the `transaction_details` table
+use_transaction_details_table = True
+
 verify_user_email = False
 
 


### PR DESCRIPTION
Adds DDL, persistence logic, and feature flag for a new `transaction_details` table.

When the `use_transaction_details_table` configuration is set to `True`, detailed information about each `save` and `save_many` transaction are written to the new table.

The persistence logic leverages the `IndexUtil`, which diffs a `Thing` with it's previous version in order to write to the `property` and `datum_*` (and other **index tables** like `edition_*`, `work_*`, etc.) tables.  `IndexUtil.update_index` was modified to return the collection of `deletes` and `inserts` used to update the index tables.

This data, along with the `transaction_id`, author key, and author's bot status is passed to `SaveImpl._add_transaction_details` for persistence in the new table.