### PR TITLE
[LOW PRIORITY] Update DDL for `transaction_details` table 

### DIFF
--- a/infogami/infobase/_dbstore/schema.sql
+++ b/infogami/infobase/_dbstore/schema.sql
@@ -80,11 +80,11 @@ RETURNS text AS
 LANGUAGE SQL;
 
 create table transaction_details (
-    id serial primary key,
+    id bigserial primary key,
     transaction_id integer references transaction(id),
     thing_id integer references thing(id),
     key_id integer references property(id),
-    property_action text,
+    action text,
     author_id integer references thing(id),
     is_bot boolean,
     created timestamp without time zone default (current_timestamp at time zone 'utc')


### PR DESCRIPTION
Updates datatype of primary key to `bigserial`.

Changes the `property_action` field to `action`.

I'm considering this low priority, as the affected query is executed when Infogami's `install` action is triggered.