### PR TITLE
Update requirements_test.txt for psycopg3

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 black
 codespell
 mypy
-psycopg2
+psycopg[binary]==3.3.3
 pytest
 ruff==0.7.3
 setuptools


### PR DESCRIPTION
Completely untested.

`requirements_test.txt` is used by our `python_tests` workflow.  Let's see if everything works.