### PR TITLE
transaction_details table update : `property_action` -> `action`

### DIFF
--- a/infogami/infobase/_dbstore/save.py
+++ b/infogami/infobase/_dbstore/save.py
@@ -139,7 +139,7 @@ class SaveImpl:
                         "key_id": r[2],
                         "author_id": author_id,
                         "is_bot": is_bot,
-                        "property_action": action_type,
+                        "action": action_type,
                     }
                 )
 


### PR DESCRIPTION
Follows #280 

Fixes broken local development instances.  

Writes actions to the `transaction_details.action` column, instead of the `property_action` column.

Additional follow-up tasks:
1. Update the `infogami` submodule in `internetarchive/openlibrary`.
2. Copy all `property_action` values to the `action` column in production `transaction_details` table.
3. Delete `property_action` column from production `transaction_details` table.