### PR TITLE
Remove recentchanges_v2 feature flag check

### DIFF
--- a/infogami/plugins/api/code.py
+++ b/infogami/plugins/api/code.py
@@ -10,7 +10,7 @@ import web
 
 import infogami
 from infogami.infobase import client
-from infogami.utils import delegate, features
+from infogami.utils import delegate
 from infogami.utils.view import safeint
 
 _VALID_JSONP_CALLBACK = re.compile(r'^[a-zA-Z_$][a-zA-Z0-9_$.]*$')
@@ -273,10 +273,7 @@ class recentchanges(delegate.page):
                 )
             )
 
-        if features.is_enabled("recentchanges_v2"):
-            return request('/_recentchanges', data=dict(query=query))
-        else:
-            return request('/versions', data=dict(query=query))
+        return request('/_recentchanges', data=dict(query=query))
 
 
 class query(delegate.page):


### PR DESCRIPTION
Part of OL issue [#12946](https://github.com/internetarchive/openlibrary/issues/12946)
The  `recentchanges_v2` feature flag was always enabled so this PR removes the `features.is_enabled("recentchanges_v2")` check from the `/recentchanges` API handler. 

Changes made :
- Remove `features` from the import in `infogami/plugins/api/code.py`
- Remove the `if/else` guard — always call `request('/_recentchanges', ...)` directly.